### PR TITLE
Build runtime-specific protobuf files from local syscalls.proto

### DIFF
--- a/rootfs/mk_rtimage.sh
+++ b/rootfs/mk_rtimage.sh
@@ -35,18 +35,12 @@ function print_runtimes() {
 function print_options() {
   echo
   echo "Options:"
-  echo -e "    --local-snapfaas PATH\tpath of the local snapfaas repository's root"
-  echo -e "    --force-protoc\tforce building protobuf definitions for the targer runtime"
+  echo -e "    --force-protoc\tforce building protobuf definitions for the target runtime"
 }
 
 PARAMS=""
 while (( "$#" )); do
   case "$1" in
-    --local-snapfaas)
-      shift
-      LOCALPATH="$1"
-      shift
-      ;;
     --force-protoc)
       FORCE='-B'
       shift
@@ -85,7 +79,7 @@ fi
 RUNTIME=$(realpath $RUNTIME)
 MYDIR=$(dirname $(realpath $0))
 
-make LOCALPATH=$LOCALPATH $FORCE -C $RUNTIME
+make $FORCE -C $RUNTIME
 make -C $MYDIR/common
 
 ## Create a temporary directory to mount the filesystem

--- a/rootfs/runtimes/nodejs/Makefile
+++ b/rootfs/runtimes/nodejs/Makefile
@@ -1,18 +1,8 @@
-SNAPFAAS=https://api.github.com/repos/princeton-sns/snapfaas/tarball/master
-
+PROTOSOURCE=$(abspath ../../../snapfaas/src/syscalls.proto)
 all: syscalls_pb.js
 
-syscalls_pb.js:
-ifdef LOCALPATH
-	@echo "Using local snapfaas at $(LOCALPATH)"
-	@protoc --proto_path=$(LOCALPATH)/snapfaas/src --js_out=. syscalls.proto
-else
-	@echo 'Using snapfaas github repository'
-	@curl -sL -H "Accept: application/vnd.github.v3+json" $(SNAPFAAS) | \
-	tar xzf - --strip-components=3 --wildcards '*/snapfaas/src/syscalls.proto'
-	@protoc --proto_path=. --js_out=import_style=commonjs,binary:. syscalls.proto
-	@rm syscalls.proto
-endif
+syscalls_pb.js: $(PROTOSOURCE)
+	@protoc --proto_path=$(dir $(PROTOSOURCE)) --js_out=import_style=commonjs,binary:. $(notdir $(PROTOSOURCE))
 
 .PHONY: clean
 clean:

--- a/rootfs/runtimes/python3/Makefile
+++ b/rootfs/runtimes/python3/Makefile
@@ -1,4 +1,3 @@
-SNAPFAAS=https://api.github.com/repos/princeton-sns/snapfaas/tarball/master
 PROTOBUF_WHL_URL=https://files.pythonhosted.org/packages/9d/82/b3131637daf2a27eab76b0de8e139ecf0f6624832c03531dce8a7d59ddc1/protobuf-4.21.0-cp37-abi3-manylinux2014_x86_64.whl
 all: google/protobuf syscalls_pb2.py
 
@@ -10,16 +9,7 @@ google/protobuf:
 	rm -Rf protobuf-*.dist-info
 
 syscalls_pb2.py:
-ifdef LOCALPATH
-	@echo "Using local snapfaas at $(LOCALPATH)"
-	@protoc --proto_path=$(LOCALPATH)/snapfaas/src --python_out=. syscalls.proto
-else
-	@echo 'Using snapfaas github repository'
-	@curl -sL -H "Accept: application/vnd.github.v3+json" $(SNAPFAAS) | \
-	tar xzf - --strip-components=3 --wildcards '*/snapfaas/src/syscalls.proto'
-	@protoc --proto_path=. --python_out=. syscalls.proto
-	@rm syscalls.proto
-endif
+	@protoc --proto_path=$(abspath ../../../snapfaas/src) --python_out=. syscalls.proto
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Updated the runtime Makefiles to compile the runtime-specific protobuf file from the local `syscalls.proto` given now all sources located in the same repository. `mk_rtimage` are updated accordingly.