### PR TITLE
Small production fixes

### DIFF
--- a/frontends/webfront/src/app.rs
+++ b/frontends/webfront/src/app.rs
@@ -234,7 +234,7 @@ impl App {
         let txn = self.dbenv.begin_ro_txn().unwrap();
         let admins: Vec<String> = txn.get(*self.default_db, &"users/admins").ok().map(|x| serde_json::from_slice(x).ok()).flatten().unwrap_or(vec![]);
         txn.commit().expect("commit");
-        if !(admins.contains(&login) || ["start_assignment", "add_to_repo", "delete_repo"].contains(&function_name.as_str())) {
+        if !(admins.contains(&login) || ["start_assignment", "add_to_repo", "delete_repo", "cos326_find_ungraded", "cos326_find_not_submitted"].contains(&function_name.as_str())) {
             return Err(Response::json(&serde_json::json!({ "error": "user not authorized to make request" })).with_status_code(401))
         }
 

--- a/snapfaas/src/labeled_fs/mod.rs
+++ b/snapfaas/src/labeled_fs/mod.rs
@@ -23,6 +23,7 @@ lazy_static::lazy_static! {
         
         let dbenv = lmdb::Environment::new()
             .set_map_size(100 * 1024 * 1024 * 1024)
+            .set_max_readers(1024)
             .open(std::path::Path::new("storage"))
             .unwrap();
 


### PR DESCRIPTION
- Increase the max_readers for lmdb dramatically from the default of 126 to 1024. This is important because we can easily have more than 126 worker threads + other processes taking a reader lock concurrently.

- Allow `invoke` access to a couple `cos326_` functions in-lieu of more general access control mechanisms for function invocation