### PR TITLE
Fix use of read_path to exclude leading string

### DIFF
--- a/snapfaas/src/fs/mod.rs
+++ b/snapfaas/src/fs/mod.rs
@@ -279,7 +279,7 @@ pub mod utils {
                 super::DirEntry::File(_) => Err(Error::BadPath)
             }
         } else {
-            Err(Error::BadPath)
+            Ok(fs.root().into())
         }
     }
 }

--- a/snapfaas/src/vm.rs
+++ b/snapfaas/src/vm.rs
@@ -493,7 +493,7 @@ impl Vm {
                     self.send_into_vm(result)?;
                 },
                 Some(SC::FsRead(req)) => {
-                    let value = fs::utils::read_path(&self.fs, req.path.split("/").map(String::from).collect()).ok().and_then(|entry| {
+                    let value = fs::utils::read_path(&self.fs, req.path.split("/").skip_while(|s| s.is_empty()).map(String::from).collect()).ok().and_then(|entry| {
                         match entry {
                             fs::DirEntry::Directory(_) => None,
                             fs::DirEntry::File(file) => self.fs.read(&file).ok()
@@ -506,7 +506,7 @@ impl Vm {
                     self.send_into_vm(result)?;
                 },
                 Some(SC::FsWrite(req)) => {
-                    let value = fs::utils::read_path(&self.fs, req.path.split("/").map(String::from).collect()).ok().and_then(|entry| {
+                    let value = fs::utils::read_path(&self.fs, req.path.split("/").skip_while(|s| s.is_empty()).map(String::from).collect()).ok().and_then(|entry| {
                         match entry {
                             fs::DirEntry::Directory(_) => None,
                             fs::DirEntry::File(file) => self.fs.write(&file, &req.data).ok()
@@ -521,7 +521,7 @@ impl Vm {
                 },
                 Some(SC::FsCreateDir(req)) => {
                     let label = proto_label_to_dc_label(req.label.clone().expect("label"));
-                    let value = fs::utils::read_path(&self.fs, req.base_dir.split("/").map(String::from).collect()).ok().and_then(|entry| {
+                    let value = fs::utils::read_path(&self.fs, req.base_dir.split("/").skip_while(|s| s.is_empty()).map(String::from).collect()).ok().and_then(|entry| {
                         match entry {
                             fs::DirEntry::Directory(dir) => {
                                 let newdir = self.fs.create_directory(label);


### PR DESCRIPTION
String formatted paths should not include an element for the (implicit) root directory