### PR TITLE
fix corner case where the last component is unallocated facet

### DIFF
--- a/snapfaas/bins/multivm/main.rs
+++ b/snapfaas/bins/multivm/main.rs
@@ -60,6 +60,7 @@ fn main() {
     let config = configs::ResourceManagerConfig::new(config_path);
 
     let fs = snapfaas::fs::FS::new(&*snapfaas::labeled_fs::DBENV);
+    fs.initialize();
     if let Ok(snapfaas::fs::DirEntry::Directory(root)) = snapfaas::fs::utils::read_path(&fs, &vec![]) {
         // set up home directories
         let fdir = fs.create_faceted_directory();


### PR DESCRIPTION
When the last component of the path is an unallocated facet for FsList, return empty vector
When the last component of the path is an unallocated facet for FsCreateXXX, if linking is allowed, allocate the facet.