### PR TITLE
update sfclient to use syscall

### DIFF
--- a/snapfaas/bins/sfclient/main.rs
+++ b/snapfaas/bins/sfclient/main.rs
@@ -1,7 +1,9 @@
 #[macro_use(crate_version, crate_authors)]
 extern crate clap;
 use clap::{App, Arg};
-use snapfaas::request;
+use labeled::buckle;
+use prost::Message;
+use snapfaas::{request, syscalls, vm};
 use std::net::TcpStream;
 use std::io::{Read, stdin};
 
@@ -25,23 +27,35 @@ fn main() -> std::io::Result<()> {
                 .long("gate")
                 .takes_value(true)
                 .required(true)
-                .help("Path of the gate to be invoked."),
+                .help("Slash separated path of the gate to be invoked. Sfclient tries to parse each component first as a Buckle label. If failure, sfclient uses it as it is."),
         )
         .get_matches();
 
 
     let addr = cmd_arguments.value_of("server address").unwrap();
-    let gate = cmd_arguments.value_of("function").unwrap().to_string();
+    let mut gate = cmd_arguments.value_of("function").unwrap();
+    if let Some(p) = gate.strip_prefix('/') {
+        gate = p;
+    }
+    let path = gate.split('/').map(|s| {
+        // try parse it as a facet, if failure, as a regular name
+        if let Ok(l) = buckle::Buckle::parse(s) {
+            let f = vm::buckle_to_pblabel(&l);
+            syscalls::PathComponent{ component: Some(syscalls::path_component::Component::Facet(f)) }
+        } else {
+            syscalls::PathComponent{ component: Some(syscalls::path_component::Component::Dscrp(s.to_string())) }
+        }
+    }).collect();
     let mut input = Vec::new();
     stdin().read_to_end(&mut input)?;
     let payload = serde_json::from_slice(&input)?;
-    let request = request::Request {
-        gate,
+    let request = syscalls::Invoke {
+        gate: path,
         payload,
     };
 
     let mut connection = TcpStream::connect(addr)?;
-    request::write_u8(&request.to_vec(), &mut connection)?;
+    request::write_u8(&request.encode_to_vec(), &mut connection)?;
     input = request::read_u8(&mut connection)?;
     let response: request::Response = serde_json::from_slice(&input)?;
     println!("{:?}", response);

--- a/snapfaas/src/worker.rs
+++ b/snapfaas/src/worker.rs
@@ -33,7 +33,6 @@ fn handle_request(req: crate::syscalls::Invoke, rsp_sender: Sender<Response>, fu
 
     tsps.arrived = precise_time_ns();
 
-    // TODO: fix this to use gate
     let fs = fs::FS::new(&*crate::labeled_fs::DBENV);
     fs::utils::clear_label();
     let function_name = fs::utils::read_path(&fs, &req.gate).ok().and_then(|entry| {


### PR DESCRIPTION
Sfclient requires the `--gate` command line argument, a slash separated path.
Sfclient removes any leading slashes and first tries to parse a component into a Buckle. If failure, keep it and use as a name string.