### PR TITLE
Sketch of functional gate invocation.

### DIFF
--- a/resources/hello.json
+++ b/resources/hello.json
@@ -1,1 +1,1 @@
-{"time": 15, "user_id": 2, "function":"hellopy2", "payload":{}}
+"{}"

--- a/rootfs/runtimes/python3/syscalls.py
+++ b/rootfs/runtimes/python3/syscalls.py
@@ -124,8 +124,11 @@ class Syscall():
         response = self._recv(syscalls_pb2.DcLabel())
         return response.secrecy
 
-    def dup_gate(self, gate, policy):
-        request = syscalls_pb2.Syscall(dupGate = syscalls_pb2.DupGate(gate=gate, policy=policy))
+    def dup_gate(self, orig, path, policy):
+        base, name, ok = split_path(path)
+        if not ok:
+            return False
+        request = syscalls_pb2.Syscall(dupGate = syscalls_pb2.DupGate(orig = convert_path(orig), baseDir = convert_path(base), name = name, policy = policy))
         self._send(req)
         response = self._recv(syscalls_pb2.DcLabel())
         return response.success

--- a/snapfaas/bins/sfclient/main.rs
+++ b/snapfaas/bins/sfclient/main.rs
@@ -1,6 +1,6 @@
 #[macro_use(crate_version, crate_authors)]
 extern crate clap;
-use clap::{App, Arg};
+use clap::{App, Arg, SubCommand};
 use labeled::buckle::{self, Clause};
 use snapfaas::request::LabeledInvoke;
 use snapfaas::{fs, request, syscalls, vm};
@@ -11,24 +11,7 @@ fn main() {
     let cmd_arguments = App::new("SnapFaaS CLI Client")
         .version(crate_version!())
         .author(crate_authors!())
-        .about("Make a request to SnapFaaS")
-        .arg(
-            Arg::with_name("server address")
-                .value_name("[ADDR:]PORT")
-                .long("server")
-                .short("s")
-                .takes_value(true)
-                .required(true)
-                .help("Address on which SnapFaaS is listening for connections"),
-        )
-        .arg(
-            Arg::with_name("gate")
-                .value_name("GATE")
-                .long("gate")
-                .takes_value(true)
-                .required(true)
-                .help("Slash separated path of the gate to be invoked. Sfclient tries to parse each component first as a Buckle label. If failure, sfclient uses it as it is."),
-        )
+        .about("All subcommands act as the principal PRINCIPAL.")
         .arg(
             Arg::with_name("principal")
                 .value_name("PRINCIPAL")
@@ -37,47 +20,130 @@ fn main() {
                 .required(true)
                 .help("Comma-separated principal string"),
         )
-        .get_matches();
+       .subcommand(
+           SubCommand::with_name("invoke")
+           .about("Act as the principal PRINCIPAL and invoke the gate at GATE")
+           .arg(
+               Arg::with_name("server address")
+                   .value_name("[ADDR:]PORT")
+                   .long("server")
+                   .short("s")
+                   .takes_value(true)
+                   .required(true)
+                   .help("Address on which SnapFaaS is listening for connections"),
+           )
+           .arg(
+               Arg::with_name("path")
+                   .value_name("GATE")
+                   .long("gate")
+                   .takes_value(true)
+                   .required(true)
+                   .value_delimiter(":")
+                   .help("Colon separated path of the gate to be invoked. Sfclient tries to parse each component first as a Buckle label. If failure, sfclient uses it as it is."),
+           )
+       )
+       .subcommand(
+           SubCommand::with_name("newgate")
+           .about("Act as the principal PRINCIPAL and create a gate at GATE from the function name.")
+            .arg(
+                Arg::with_name("path")
+                    .value_name("GATE")
+                    .long("gate")
+                    .takes_value(true)
+                    .required(true)
+                    .value_delimiter(":")
+                    .help("Colon separated path of the gate to be created. Sfclient tries to parse each component first as a Buckle label. If failure, sfclient uses it as it is."),
+            )
+            .arg(
+                Arg::with_name("policy")
+                    .value_name("POLICY")
+                    .long("policy")
+                    .takes_value(true)
+                    .required(true)
+                    .help("A parsable Buckle string piggybacking the gate's policy. The secrecy should be the gate's privilege. The integrity should be the gate's integrity."),
+            )
+            .arg(
+                Arg::with_name("function")
+                    .value_name("FUNCTION NAME")
+                    .long("function")
+                    .takes_value(true)
+                    .required(true)
+                    .help("Function name string."),
+            )
+       )
+       .get_matches();
 
 
-    let addr = cmd_arguments.value_of("server address").unwrap();
     let principal: Vec<&str> = cmd_arguments.value_of("principal").unwrap().split(',').collect();
-    let mut gate = cmd_arguments.value_of("function").unwrap();
-    if let Some(p) = gate.strip_prefix('/') {
-        gate = p;
-    }
-    let path = gate.split('/').map(|s| {
-        // try parse it as a facet, if failure, as a regular name
-        if let Ok(l) = buckle::Buckle::parse(s) {
-            let f = vm::buckle_to_pblabel(&l);
-            syscalls::PathComponent{ component: Some(syscalls::path_component::Component::Facet(f)) }
-        } else {
-            syscalls::PathComponent{ component: Some(syscalls::path_component::Component::Dscrp(s.to_string())) }
-        }
-    }).collect();
     let fs = snapfaas::fs::FS::new(&*snapfaas::labeled_fs::DBENV);
     fs::utils::clear_label();
     fs::utils::set_my_privilge([Clause::new_from_vec(vec![principal])].into());
-    let gate = match fs::utils::read_path(&fs, &path) {
-        Ok(fs::DirEntry::Gate(g)) => fs.invoke_gate(&g).ok(),
-        _ => None,
-    };
-    if gate.is_none() {
-        eprintln!("Cannot invoke the gate.");
-        return;
-    }
-    let mut input = Vec::new();
-    stdin().read_to_end(&mut input).unwrap();
-    let payload = serde_json::from_slice(&input).unwrap();
-    let request = LabeledInvoke {
-        gate: gate.unwrap(),
-        label: fs::utils::get_current_label(),
-        payload,
-    };
+    match cmd_arguments.subcommand() {
+        ("invoke", Some(sub_m)) => {
+            let addr = sub_m.value_of("server address").unwrap();
+            let path: Vec<&str> = sub_m.values_of("path").unwrap().collect();
+            let path = path.iter().map(|s| {
+                // try parse it as a facet, if failure, as a regular name
+                if let Ok(l) = buckle::Buckle::parse(s) {
+                    let f = vm::buckle_to_pblabel(&l);
+                    syscalls::PathComponent{ component: Some(syscalls::path_component::Component::Facet(f)) }
+                } else {
+                    syscalls::PathComponent{ component: Some(syscalls::path_component::Component::Dscrp(s.to_string())) }
+                }
+            }).collect();
+            let gate = match fs::utils::read_path(&fs, &path) {
+                Ok(fs::DirEntry::Gate(g)) => fs.invoke_gate(&g).ok(),
+                _ => None,
+            };
+            if gate.is_none() {
+                eprintln!("Cannot invoke the gate.");
+                return;
+            }
+            let mut input = Vec::new();
+            stdin().read_to_end(&mut input).unwrap();
+            let payload = serde_json::from_slice(&input).unwrap();
+            let request = LabeledInvoke {
+                gate: gate.unwrap(),
+                label: fs::utils::get_current_label(),
+                payload,
+            };
 
-    let mut connection = TcpStream::connect(addr).unwrap();
-    request::write_u8(serde_json::to_vec(&request).unwrap().as_ref(), &mut connection).unwrap();
-    input = request::read_u8(&mut connection).unwrap();
-    let response: request::Response = serde_json::from_slice(&input).unwrap();
-    println!("{:?}", response);
+            let mut connection = TcpStream::connect(addr).unwrap();
+            request::write_u8(serde_json::to_vec(&request).unwrap().as_ref(), &mut connection).unwrap();
+            input = request::read_u8(&mut connection).unwrap();
+            let response: request::Response = serde_json::from_slice(&input).unwrap();
+            println!("{:?}", response);
+        },
+        ("newgate", Some(sub_m)) => {
+            let function = sub_m.value_of("function").unwrap().to_string();
+            let policy = buckle::Buckle::parse(sub_m.value_of("policy").unwrap());
+            if policy.is_err() {
+                eprintln!("Bad gate policy.");
+                return;
+            }
+            let policy = policy.unwrap();
+            let mut path = sub_m.values_of("path").unwrap().collect::<Vec<&str>>();
+            if let Some(name) = path.pop() {
+                let base_dir = path.iter().map(|s| {
+                    // try parse it as a facet, if failure, as a regular name
+                    if let Ok(l) = buckle::Buckle::parse(s) {
+                        let f = vm::buckle_to_pblabel(&l);
+                        syscalls::PathComponent{ component: Some(syscalls::path_component::Component::Facet(f)) }
+                    } else {
+                        syscalls::PathComponent{ component: Some(syscalls::path_component::Component::Dscrp(s.to_string())) }
+                    }
+                }).collect();
+
+                // TODO: use global function name for now
+                if let Err(e) = fs::utils::create_gate(&fs, &base_dir, name.to_string(), policy, function) {
+                    eprintln!("Cannot create the gate at the path {:?}", e);
+                }
+            } else {
+                eprintln!("Bad path");
+            }
+        },
+        (&_, _) => {
+            eprintln!("{}", cmd_arguments.usage());
+        }
+    }
 }

--- a/snapfaas/src/fs/mod.rs
+++ b/snapfaas/src/fs/mod.rs
@@ -310,7 +310,8 @@ impl<S: BackingStore> FS<S> {
         CURRENT_LABEL.with(|current_label| {
             PRIVILEGE.with(|opriv| {
                 // implicit endorsement
-                *current_label.borrow_mut() = current_label.borrow().clone().endorse(&*opriv.borrow());
+                let clone = current_label.borrow().clone();
+                *current_label.borrow_mut() = clone.endorse(&*opriv.borrow());
                 // check integrity
                 if current_label.borrow().integrity.implies(&gate.invoking) {
                     Ok(gate.clone())
@@ -538,7 +539,8 @@ pub mod utils {
                     match de {
                         super::DirEntry::Directory(dir) => {
                             // implicitly raising the secrecy
-                            *current_label.borrow_mut() = current_label.borrow().clone().lub(Buckle::new(dir.label.secrecy.clone(), true));
+                            let clone = current_label.borrow().clone();
+                            *current_label.borrow_mut() = clone.lub(Buckle::new(dir.label.secrecy.clone(), true));
                             match comp.component.as_ref() {
                                 Some(PC::Dscrp(s)) => fs.list(dir)?.get(s).map(Clone::clone).ok_or(Error::BadPath),
                                 _ => Err(Error::BadPath),
@@ -549,7 +551,8 @@ pub mod utils {
                                 Some(PC::Facet(f)) => {
                                     let facet = crate::vm::pblabel_to_buckle(f);
                                     // implicitly raising the secrecy
-                                    *current_label.borrow_mut() = current_label.borrow().clone().lub(Buckle::new(facet.secrecy.clone(), true));
+                                    let clone = current_label.borrow().clone();
+                                    *current_label.borrow_mut() = clone.lub(Buckle::new(facet.secrecy.clone(), true));
                                     fs.open_facet(&fdir, &facet).map(|d| DirEntry::Directory(d))
                                 },
                                 _ => Err(Error::BadPath),
@@ -562,7 +565,8 @@ pub mod utils {
                 match direntry {
                     super::DirEntry::Directory(dir) => {
                         // implicitly raising the secrecy
-                        *current_label.borrow_mut() = current_label.borrow().clone().lub(Buckle::new(dir.label.secrecy.clone(), true));
+                        let clone = current_label.borrow().clone();
+                        *current_label.borrow_mut() = clone.lub(Buckle::new(dir.label.secrecy.clone(), true));
                         match last.component.as_ref() {
                             Some(PC::Dscrp(s)) => fs.list(dir)?.get(s).map(Clone::clone).ok_or(Error::BadPath),
                             _ => Err(Error::BadPath),
@@ -573,7 +577,8 @@ pub mod utils {
                             Some(PC::Facet(f)) => {
                                 let facet = crate::vm::pblabel_to_buckle(f);
                                 // implicitly raising the secrecy
-                                *current_label.borrow_mut() = current_label.borrow().clone().lub(Buckle::new(facet.secrecy.clone(), true));
+                                let clone = current_label.borrow().clone();
+                                *current_label.borrow_mut() = clone.lub(Buckle::new(facet.secrecy.clone(), true));
                                 match fs.open_facet(&fdir, &facet) {
                                     Ok(d) => Ok(DirEntry::Directory(d)),
                                     Err(Error::UnallocatedFacet) => Err(Error::FacetedDir(fdir, facet)),
@@ -595,7 +600,9 @@ pub mod utils {
     pub fn create_gate<S: Clone + BackingStore>(fs: &FS<S>, base_dir: &Vec<syscalls::PathComponent>, name: String, policy: Buckle, image: String) -> Result<(), Error> {
         let gate = fs.create_gate(policy.secrecy, policy.integrity, image).map_err(|e| Error::GateError(e))?;
         CURRENT_LABEL.with(|current_label| {
-            PRIVILEGE.with(|opriv| { *current_label.borrow_mut() = current_label.borrow().clone().endorse(&*opriv.borrow())});
+            PRIVILEGE.with(|opriv| {
+                let clone = current_label.borrow().clone();
+                *current_label.borrow_mut() = clone.endorse(&*opriv.borrow())});
         });
         match read_path(&fs, base_dir) {
             Ok(DirEntry::Directory(dir)) =>
@@ -612,7 +619,8 @@ pub mod utils {
 
     pub fn taint_with_label(label: Buckle) -> Buckle {
         CURRENT_LABEL.with(|l| {
-            *l.borrow_mut() = l.borrow().clone().lub(label);
+            let clone = l.borrow().clone();
+            *l.borrow_mut() = clone.lub(label);
             l.borrow().clone()
         })
     }

--- a/snapfaas/src/message.rs
+++ b/snapfaas/src/message.rs
@@ -5,7 +5,7 @@ use crate::vm::Vm;
 use crate::resource_manager;
 use crate::metrics::RequestTimestamps;
 
-pub type RequestInfo = (crate::syscalls::Invoke, Sender<Response>, RequestTimestamps);
+pub type RequestInfo = (crate::syscalls::LabeledInvoke, Sender<Response>, RequestTimestamps);
 
 #[derive(Debug)]
 pub enum Message {

--- a/snapfaas/src/message.rs
+++ b/snapfaas/src/message.rs
@@ -1,11 +1,11 @@
 use std::sync::mpsc::Sender;
 
-use crate::request::Response;
+use crate::request::{Response, LabeledInvoke};
 use crate::vm::Vm;
 use crate::resource_manager;
 use crate::metrics::RequestTimestamps;
 
-pub type RequestInfo = (crate::syscalls::LabeledInvoke, Sender<Response>, RequestTimestamps);
+pub type RequestInfo = (LabeledInvoke, Sender<Response>, RequestTimestamps);
 
 #[derive(Debug)]
 pub enum Message {

--- a/snapfaas/src/request.rs
+++ b/snapfaas/src/request.rs
@@ -1,6 +1,7 @@
 use std::io::{Error, ErrorKind, Write, Read};
+use labeled::buckle::Buckle;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+//use serde_json::Value;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RequestStatus {
@@ -24,10 +25,17 @@ impl Response {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LabeledInvoke {
+    pub gate: crate::fs::Gate,
+    pub payload: String,
+    pub label: Buckle,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Request {
     pub gate: String,
-    pub payload: Value,
+    pub payload: serde_json::Value,
 }
 
 impl Request {
@@ -43,7 +51,7 @@ impl Request {
 }
 
 /// Given a [u8], parse it to a Requst value
-pub fn parse_u8_request(buf: Vec<u8>) -> Result<Request, serde_json::Error> {
+pub fn parse_u8_invoke(buf: Vec<u8>) -> Result<LabeledInvoke, serde_json::Error> {
     serde_json::from_slice(&buf)
 }
 

--- a/snapfaas/src/syscalls.proto
+++ b/snapfaas/src/syscalls.proto
@@ -2,11 +2,6 @@ syntax = "proto3";
 
 package snapfaas.syscalls;
 
-message LabeledInvoke {
-  Invoke invoke = 1;
-  Buckle label = 2;
-}
-
 message Invoke {
   repeated PathComponent gate = 1;
   string payload = 2;

--- a/snapfaas/src/syscalls.proto
+++ b/snapfaas/src/syscalls.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package snapfaas.syscalls;
 
+message LabeledInvoke {
+  Invoke invoke = 1;
+  Buckle label = 2;
+}
+
 message Invoke {
   repeated PathComponent gate = 1;
   string payload = 2;
@@ -9,11 +14,11 @@ message Invoke {
 
 message DupGate {
   repeated PathComponent gate = 1;
-  DcLabel policy = 2;
+  Buckle policy = 2;
 }
 
 message DeclassifyResponse {
-  optional DcLabel label = 1;
+  optional Buckle label = 1;
 }
 
 message TokenList {
@@ -30,7 +35,7 @@ message Component {
   repeated Clause clauses = 1;
 }
 
-message DcLabel {
+message Buckle {
   // None means DcFalse, empty clauses means DcTrue, otherwise DcFormula
   optional Component secrecy = 1;
   // None means DcFalse, empty clauses means DcTrue, otherwise DcFormula
@@ -95,7 +100,7 @@ message GetCurrentLabel {
 message PathComponent {
   oneof component {
     string dscrp = 1;
-    DcLabel facet = 2;
+    Buckle facet = 2;
   }
 }
 
@@ -111,17 +116,17 @@ message FSWrite {
 message FSCreateDir {
   repeated PathComponent baseDir = 1;
   string name = 2;
-  DcLabel label = 3;
+  Buckle label = 3;
 }
 
 message FSCreateFile {
   repeated PathComponent baseDir = 1;
   string name = 2;
-  DcLabel label = 3;
+  Buckle label = 3;
 }
 
 message ExercisePrivilege {
-  DcLabel target = 1;
+  Buckle target = 1;
 }
 
 message BlobCreate {
@@ -193,7 +198,7 @@ message Syscall {
     ReadKey readKey = 2;
     WriteKey writeKey = 3;
     GetCurrentLabel getCurrentLabel = 4;
-    DcLabel taintWithLabel = 5;
+    Buckle taintWithLabel = 5;
     GithubRest githubRest = 6;
     Invoke invoke = 7;
     FSRead fsRead = 8;

--- a/snapfaas/src/syscalls.proto
+++ b/snapfaas/src/syscalls.proto
@@ -8,8 +8,10 @@ message Invoke {
 }
 
 message DupGate {
-  repeated PathComponent gate = 1;
-  Buckle policy = 2;
+  repeated PathComponent orig = 1;
+  repeated PathComponent baseDir = 2;
+  string name = 3;
+  Buckle policy = 4;
 }
 
 message DeclassifyResponse {

--- a/snapfaas/src/vm.rs
+++ b/snapfaas/src/vm.rs
@@ -458,11 +458,10 @@ impl Vm {
                     self.send_into_vm(result.encode_to_vec())?;
                 },
                 Some(SC::DupGate(req)) => {
-                    let value = fs::utils::read_path(&self.fs, &req.gate).ok().and_then(|entry| {
-                        match entry {
+                    let value = fs::utils::read_path(&self.fs, &req.orig).ok().and_then(|entry| { match entry {
                             fs::DirEntry::Gate(gate) => {
                                 let policy = pblabel_to_buckle(&req.policy.unwrap());
-                                self.fs.dup_gate(policy, &gate).ok()
+                                fs::utils::create_gate(&self.fs, &req.base_dir, req.name, policy, gate.image).ok()
                             },
                             _ => None,
                         }

--- a/snapfaas/src/vm.rs
+++ b/snapfaas/src/vm.rs
@@ -412,6 +412,7 @@ impl Vm {
             };
             match Syscall::decode(buf.as_ref()).map_err(|e| Error::Rpc(e))?.syscall {
                 Some(SC::Response(r)) => {
+                    debug!("function response: {}", r.payload);
                     return Ok(r.payload);
                 }
                 Some(SC::BuckleParse(s)) => {

--- a/snapfaas/src/worker.rs
+++ b/snapfaas/src/worker.rs
@@ -13,7 +13,7 @@ use log::{error, debug};
 use time::precise_time_ns;
 
 use crate::message::Message;
-use crate::request::{RequestStatus, Response};
+use crate::request::{RequestStatus, Response, LabeledInvoke};
 use crate::vm;
 use crate::metrics::{self, RequestTimestamps};
 use crate::resource_manager;
@@ -28,31 +28,15 @@ pub struct Worker {
     pub thread: JoinHandle<()>,
 }
 
-fn handle_request(req: crate::syscalls::LabeledInvoke, rsp_sender: Sender<Response>, func_req_sender: Sender<Message>, vm_req_sender: Sender<Message>, vm_listener: UnixListener, mut tsps: RequestTimestamps, stat: &mut metrics::WorkerMetrics, cid: u32) {
-    debug!("invoke syscall: {:?}", &req.invoke);
+fn handle_request(req: LabeledInvoke, rsp_sender: Sender<Response>, func_req_sender: Sender<Message>, vm_req_sender: Sender<Message>, vm_listener: UnixListener, mut tsps: RequestTimestamps, stat: &mut metrics::WorkerMetrics, cid: u32) {
+    debug!("invoke: {:?}", &req);
 
     tsps.arrived = precise_time_ns();
 
-    let fs = fs::FS::new(&*crate::labeled_fs::DBENV);
-    if req.invoke.is_none() || req.label.is_none() {
-        let id = thread::current().id();
-        error!("[Worker {:?}] empty invoke or label: {:?}", id, req);
-        return;
-    }
     fs::utils::clear_label();
-    fs::utils::taint_with_label(crate::vm::pblabel_to_buckle(&req.label.unwrap()));
-    let req = req.invoke.unwrap();
-    let function_name = fs::utils::read_path(&fs, &req.gate).ok().and_then(|entry| {
-        match entry {
-            fs::DirEntry::Gate(gate) => fs.invoke_gate(&gate).ok(),
-            _ => None,
-        }
-    });
-    if function_name.is_none() {
-        let _ = rsp_sender.send(Response { status: RequestStatus::GateNotExist });
-        return;
-    }
-    let function_name = function_name.unwrap();
+    fs::utils::taint_with_label(labeled::buckle::Buckle::new(req.label.secrecy, true));
+    fs::utils::set_my_privilge(req.gate.privilege);
+    let function_name = req.gate.image;
     let mut i = 0;
     let result = loop {
         let mut tsps = tsps.clone();


### PR DESCRIPTION
The scheduler now processes snapfass::request::LabeledInvoke.

The scheduler does no invoke check. An entry invocation gets checked inside sfclient. Invokes from a VM gets checked before submitted to the scheduler.

Sfclient now supports command-line invokes and new gate creation.