### PR TITLE
Checking cached VMs' labels

### DIFF
--- a/snapfaas/src/message.rs
+++ b/snapfaas/src/message.rs
@@ -14,4 +14,5 @@ pub enum Message {
     GetVm(String, Sender<Result<Vm, resource_manager::Error>>),
     ReleaseVm(Vm),
     DeleteVm(Vm),
+    NewVm(String, Sender<Result<Vm, resource_manager::Error>>),
 }

--- a/snapfaas/src/resource_manager.rs
+++ b/snapfaas/src/resource_manager.rs
@@ -90,6 +90,9 @@ impl ResourceManager {
                             Message::GetVm(function, vm_sender) => {
                                 vm_sender.send(self.acquire_vm(&function)).expect("Failed to send VM");
                             },
+                            Message::NewVm(function, vm_sender) => {
+                                vm_sender.send(self.allocate(&function)).expect("Failed to send VM");
+                            }
                             Message::ReleaseVm(vm) => {
                                 self.release(vm);
                             },

--- a/snapfaas/src/vm.rs
+++ b/snapfaas/src/vm.rs
@@ -117,7 +117,7 @@ pub struct Vm {
     allow_network: bool,
     function_name: String,
     function_config: FunctionConfig,
-    //current_label: DCLabel,
+    pub label: Buckle,
     //privilege: Component,
     handle: Option<VmHandle>,
     blobstore: blobstore::Blobstore,
@@ -146,7 +146,7 @@ impl Vm {
             // We should also probably have a clearance to mitigate side channel attacks, but
             // meh for now...
             /// Starting label with public secrecy and integrity has app-name
-            //current_label: DCLabel::new(true, [[function_name.clone()]]),
+            label: Buckle::new(true, true),
             //privilege: Component::formula([[function_name]]),
             handle: None,
             blobstore: Default::default(),

--- a/snapfaas/src/worker.rs
+++ b/snapfaas/src/worker.rs
@@ -74,6 +74,10 @@ fn handle_request(req: LabeledInvoke, rsp_sender: Sender<Response>, func_req_sen
                     vm_req_sender.send(Message::NewVm(function_name.clone(), tx)).expect("Failed to send NewVm request");
                     if let Ok(newvm) = rx.recv().expect("Failed to receive NewVm response") {
                         vm = newvm;
+                        if let Err(_) = vm.launch(Some(func_req_sender.clone()), vm_listener.try_clone().expect("clone unix listener"), cid, false, None) {
+                            vm_req_sender.send(Message::DeleteVm(vm)).unwrap();
+                            continue;
+                        }
                     } else {
                         continue;
                     }


### PR DESCRIPTION
The PR contains the change that checks a cached VM's label is less tainted than the invocation request.

Two things to note:
1. The path traversal to fetch the gate object and the check both happen at the invokee side.
2. Due to 1, the effective label of the request is the invoker VM's label at the time of invocation joined by all labels of the gate's parent directories.