### PR TITLE
Add Redirect Gate

### DIFF
--- a/functions/fsutil/workload.py
+++ b/functions/fsutil/workload.py
@@ -11,10 +11,37 @@ def handle(request, syscall):
         memory = args['memory']
         runtime = args['runtime']
         ret['success'] = syscall.fs_creategate(path, policy, app_blob, memory, runtime)
+    if op == 'create-redirect-gate':
+        path = args['path']
+        policy = args['policy']
+        redirect_path = args['redirect_path']
+        ret['success'] = syscall.fs_createredirectgate(path, policy, redirect_path)
+    elif op == 'create-blob':
+        blob = request['input-blob']
+        path = args['path']
+        label = None
+        if 'label' in args:
+            label = args['label']
+        if syscall.fs_linkblob(blob, path, label):
+            ret['success'] = True
+            #trigger_ret = None
+            #if 'triggers' in args:
+            #    trigger_ret = trigger(args['triggers'], syscall, op, path)
+            #ret['trigger_status'] = trigger_ret
+        else:
+            ret['success'] = False
     elif op == 'create-file':
         path = args['path']
         label = args['label']
-        ret['success'] = syscall.fs_createfile(path, label)
+        if syscall.fs_createfile(path, label):
+            ret['success'] = True
+            #trigger_ret = None
+            #if 'triggers' in args:
+            #    trigger(args['triggers'], syscall, op, path)
+            #    trigger_ret = trigger(args['triggers'], syscall, op, path)
+            #ret['trigger_status'] = trigger_ret
+        else:
+            ret['success'] = False
     elif op == 'read-file':
         path = args['path']
         v = syscall.fs_read(path)
@@ -56,19 +83,17 @@ def handle(request, syscall):
     else:
         ret['success'] = False
         ret['error'] = '[fsutil] unknown op'
-    #if op == 'createdir':
-    #    success = syscall.fs_createdir(args['path']) is not None
-    #elif op == 'createfile':
-    #    success = syscall.fs_createfile(['home', user_facet, 'file1'], label=user_facet)
-    #elif op == 'write':
-    #    data = bytes(req['args']['data'].encode('utf-8'))
-    #    success = syscall.fs_write(['home', user_facet, 'file1'], data)
-    #elif op == 'read':
-    #    success = syscall.fs_read(['home', user_facet, 'file1']) is not None
-    #elif op == 'list':
-    #    success = syscall.fs_list(
-    #elif op == 'deleteuserfile':
-    #    success = syscall.fs_delete(['home', user_facet, 'file1'])
-    #else:
-    #    return {'error': 'unsupported op.'}
     return ret
+
+#def trigger(triggers, syscall, op, path):
+#    ret = {'success': [], 'failure': []}
+#    for gate in triggers:
+#        payload = {
+#            'source-op': op,
+#            'object-path': path,
+#        }
+#        if syscall.invoke(gate, json.dumps(payload)):
+#            ret['success'].append(gate)
+#        else:
+#            ret['failure'].append(gate)
+#    return ret

--- a/functions/fsutil/workload.py
+++ b/functions/fsutil/workload.py
@@ -11,7 +11,7 @@ def handle(request, syscall):
         memory = args['memory']
         runtime = args['runtime']
         ret['success'] = syscall.fs_creategate(path, policy, app_blob, memory, runtime)
-    if op == 'create-redirect-gate':
+    elif op == 'create-redirect-gate':
         path = args['path']
         policy = args['policy']
         redirect_path = args['redirect_path']

--- a/rootfs/runtimes/python3/syscalls.py
+++ b/rootfs/runtimes/python3/syscalls.py
@@ -241,7 +241,7 @@ class Syscall():
         response = self._recv(syscalls_pb2.WriteKeyResponse())
         return response.success
 
-    def fs_createblobbyname(self, path, blobname: str, label: syscalls_pb2.Buckle=None):
+    def fs_linkblob(self, path, blobname: str, label: str=None):
         """Link `blobname` into the file system at `path`."""
         req = syscalls_pb2.Syscall(fsLinkBlob=syscalls_pb2.FSLinkBlob(path=path, blobname=blobname, label=label))
         self._send(req)
@@ -250,6 +250,12 @@ class Syscall():
 
     def fs_creategate(self, path: str, policy: str, app: str, memory: int, runtime: str):
         req = syscalls_pb2.Syscall(fsCreateGate=syscalls_pb2.FSCreateGate(path=path, policy=policy, appImage=app, memory=memory, runtime=runtime))
+        self._send(req)
+        response = self._recv(syscalls_pb2.WriteKeyResponse())
+        return response.success
+
+    def fs_createredirectgate(self, path: str, policy: str, redirect_path: str):
+        req = syscalls_pb2.Syscall(fsCreateRedirectGate=syscalls_pb2.FSCreateRedirectGate(path=path, policy=policy, redirectPath=redirect_path))
         self._send(req)
         response = self._recv(syscalls_pb2.WriteKeyResponse())
         return response.success

--- a/snapfaas/src/fs/bootstrap.rs
+++ b/snapfaas/src/fs/bootstrap.rs
@@ -50,7 +50,7 @@ fn create_fsutil_redirect_target<S: Clone + BackingStore>(
     )
     .expect("create redirection target directory");
     let mut target_directory = FSTN_IMAGE_BASE.clone();
-    target_directory.push_dscrp("fsutil".to_string());
+    target_directory.push_dscrp("fsutil_config".to_string());
     super::utils::create_blob(
         faasten_fs,
         target_directory.clone(),
@@ -163,7 +163,7 @@ pub fn prepare_fs<S: Clone + BackingStore>(faasten_fs: &super::FS<S>, config_pat
         python_blob,
         kernel_blob,
     );
-    let fsutil_gate_policy = buckle::Buckle::parse("t,t").unwrap();
+    let fsutil_gate_policy = buckle::Buckle::parse("T,T").unwrap();
     let mut redirect_path = FSTN_IMAGE_BASE.clone();
     redirect_path.push_dscrp("fsutil_config".to_string());
     fs::utils::create_redirect_gate(
@@ -196,7 +196,7 @@ pub fn register_user_fsutil<S: Clone + BackingStore>(fs: &super::FS<S>, login: S
     // generate the per-user fsutil gate, acting on behalf of the user
     let ufacet = buckle::Buckle::parse(&format!("{0},{0}", login)).unwrap();
     super::utils::set_my_privilge(ufacet.integrity.clone());
-    let faasten_fsutil = super::path::Path::parse("home:<T,faasten>:fsutil").unwrap();
+    let faasten_fsutil = super::path::Path::parse("home:<T,faasten>:fsutil_redirect_gate").unwrap();
     let user_home = super::path::Path::parse("~").unwrap();
     if let Err(e) =
         super::utils::dup_gate(fs, faasten_fsutil, user_home, "fsutil".to_string(), ufacet)

--- a/snapfaas/src/fs/mod.rs
+++ b/snapfaas/src/fs/mod.rs
@@ -1351,17 +1351,20 @@ pub mod utils {
                     object_id: orig.object_id,
                 };
                 match read_path(fs, base_dir) {
-                    Ok(entry) => match entry {
-                        DirEntry::Directory(dir) => fs
-                            .link(&dir, name, DirEntry::Gate(gate))
-                            .map(|_| ())
-                            .map_err(|e| Error::from(e)),
-                        DirEntry::FacetedDirectory(fdir) => fs
-                            .faceted_link(&fdir, None, name, DirEntry::Gate(gate))
-                            .map(|_| ())
-                            .map_err(|e| Error::from(e)),
-                        _ => Err(Error::BadPath),
-                    },
+                    Ok(entry) => {
+                        endorse_with_full();
+                        match entry {
+                            DirEntry::Directory(dir) => fs
+                                .link(&dir, name, DirEntry::Gate(gate))
+                                .map(|_| ())
+                                .map_err(|e| Error::from(e)),
+                            DirEntry::FacetedDirectory(fdir) => fs
+                                .faceted_link(&fdir, None, name, DirEntry::Gate(gate))
+                                .map(|_| ())
+                                .map_err(|e| Error::from(e)),
+                            _ => Err(Error::BadPath),
+                        }
+                    }
                     Err(Error::FacetedDir(fdir, facet)) => {
                         endorse_with_full();
                         fs.faceted_link(&fdir, Some(&facet), name, DirEntry::Gate(gate))

--- a/snapfaas/src/fs/path.rs
+++ b/snapfaas/src/fs/path.rs
@@ -1,4 +1,5 @@
 use labeled::buckle::Buckle;
+use serde::{Deserialize, Serialize};
 
 use crate::syscall_server::pblabel_to_buckle;
 use crate::syscalls;
@@ -9,13 +10,13 @@ pub enum Error {
     InvalidFacet,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Component {
     Dscrp(String),
     Facet(Buckle),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Path {
     components: Vec<Component>,
 }

--- a/snapfaas/src/syscalls.proto
+++ b/snapfaas/src/syscalls.proto
@@ -21,11 +21,6 @@ message InvokeGate {
   string payload = 2;
 }
 
-message InvokeRedirectGate {
-  string gate = 1;
-  string payload = 2;
-}
-
 message InvokeFunction {
   string function = 1;
   string payload = 2;
@@ -264,6 +259,5 @@ message Syscall {
     InvokeFunction invokeFunction = 28;
     FSCreateBlobByName fsCreateBlobByName = 29;
     FSCreateRedirectGate fsCreateRedirectGate = 30;
-    InvokeRedirectGate invokeRedirectGate = 31;
   }
 }

--- a/snapfaas/src/syscalls.proto
+++ b/snapfaas/src/syscalls.proto
@@ -21,6 +21,11 @@ message InvokeGate {
   string payload = 2;
 }
 
+message InvokeRedirectGate {
+  string gate = 1;
+  string payload = 2;
+}
+
 message InvokeFunction {
   string function = 1;
   string payload = 2;
@@ -212,9 +217,19 @@ message FSCreateFacetedDir {
 message FSCreateGate {
   string path = 1;
   string policy = 2;
+  // blobname, direct pointer to the image
   string appImage = 3;
   uint64 memory = 4;
+  // Legal values are Faasten-supported language runtimes
+  // currently just python
   string runtime = 5;
+}
+
+message FSCreateRedirectGate {
+  string path = 1;
+  string policy = 2;
+  // fs path
+  string redirectPath = 3;
 }
 
 message Syscall {
@@ -248,5 +263,7 @@ message Syscall {
     FSCreateGate fsCreateGate = 27;
     InvokeFunction invokeFunction = 28;
     FSCreateBlobByName fsCreateBlobByName = 29;
+    FSCreateRedirectGate fsCreateRedirectGate = 30;
+    InvokeRedirectGate invokeRedirectGate = 31;
   }
 }


### PR DESCRIPTION
How is a redirect gate different from a normal gate?
* A normal gate object stores pointers to blob images required to boot a virtual machine for a function (kernel, runtime/root file system, app file system) and the virtual machine memory size.
* A regular gate object stores a Faasten-FS path, a redirection. The path should be a directory that has four entries---a blob entry named "kernel", a blob entry named "runtime", a blob entry named "app", and a file entry named "memory". These entries correspond to the three blob pointers and the specification on the virtual machine memory size in a normal gate object.

Changes to Faasten-FS interface  (`snapfaas/src/fs/mod.rs`):
* add a bool field `redirect` to the DirEntry type, Gate.
* add another Faasten-FS primitive `invoke_redirect` that returns the stored redirect path.
*  no change to CloudCall `invoke` signature; instead, the CloudCall checks `redirect` field internally.

Changes to bootstrap (`snapfaas/src/fs/bootstrap.rs`):
* `:home:<T,faasten>:fsutil_redirect_gate` is created
* the gate above stores the redirect path `:home:<T,faasten>:fsutil_config` (a directory)
* needed blobs images are linked into the redirect directory; memory file is created.
* at login, user-specific `:home:<login,login>:fsutil` now is duplicated from `:home:<T,faasten>:fsutil_redirect_gate`

Test:
* Deployed on sns60 and tested `prepare_fs --update_fsutil /path/to/local/fsutil/img`

Fix:
* Fixed a missing implicit endorsement in CloudCall `invoke`.