### PR TITLE
Bits and bobs towards in pursuit of benchmarks working

### DIFF
--- a/bootstrap-config.yml
+++ b/bootstrap-config.yml
@@ -1,4 +1,4 @@
-kernel: /home/yuetan/faasten/resources/images/vmlinux-4.20.0
-python: /home/yuetan/faasten/rootfs/python3.ext4
-fsutil: /home/yuetan/faasten/functions/output/fsutil.img
+kernel: resources/images/vmlinux-4.20.0
+python: functions/python3.ext4
+fsutil: functions/output/fsutil.img
 other_runtimes: []

--- a/rootfs/runtimes/python3/syscalls.py
+++ b/rootfs/runtimes/python3/syscalls.py
@@ -347,6 +347,7 @@ class NewBlob():
 class Blob():
     def __init__(self, fd, syscall):
         self.fd = fd
+        self.offset = 0
         self.syscall = syscall
 
     def _blob_read(self, offset=None, length=None):
@@ -365,15 +366,25 @@ class Blob():
             return self._blob_read()
         else:
             while size > 0:
-                data = self._blob_read(size)
+                data = self._blob_read(self.offset, size)
                 # reaches EOF
                 if len(data) == 0:
                     return buf
                 buf.extend(data)
-                offset += len(data)
+                self.offset += len(data)
                 size -= len(data)
         # size = 0
         return buf
+
+    def tell(self):
+        return self.offset
+
+    def seek(self, offset, whence=0):
+        # TODO handle whence of 2: seek from end of file
+        if whence == 1:
+            self.offset += offset
+        else:
+            self.offset = offset
 
 class CreateBlobError(Exception):
     pass

--- a/rootfs/runtimes/python3/syscalls.py
+++ b/rootfs/runtimes/python3/syscalls.py
@@ -207,6 +207,23 @@ class Syscall():
         response = self._recv(syscalls_pb2.ReadKeyResponse())
         return response.value
 
+    @contextmanager
+    def fs_openblob(self, path: str):
+        """Open the blob at the `path`.
+
+        Returns:
+            Blob: if success
+            None: otherwise
+        """
+        req = syscalls_pb2.Syscall(fsOpenBlob = syscalls_pb2.FSOpenBlob(path=path))
+        self._send(req)
+        response = self._recv(syscalls_pb2.FSOpenBlobResponse())
+        if response.name:
+            with self.open_blob(response.name) as blob:
+                yield blob
+        else:
+            None
+
     def fs_write(self, path: str, data):
         """Overwrite the file at the `path` with the `data`.
         The host-side handler always endorse before writing.
@@ -257,7 +274,7 @@ class Syscall():
 
     def fs_linkblob(self, path, blobname: str, label: str=None):
         """Link `blobname` into the file system at `path`."""
-        req = syscalls_pb2.Syscall(fsLinkBlob=syscalls_pb2.FSLinkBlob(path=path, blobname=blobname, label=label))
+        req = syscalls_pb2.Syscall(fsCreateBlobByName=syscalls_pb2.FSCreateBlobByName(path=path, blobname=blobname, label=label))
         self._send(req)
         response = self._recv(syscalls_pb2.WriteKeyResponse())
         return response.success
@@ -359,12 +376,12 @@ class Blob():
         raise ReadBlobError
 
     def read(self, size=None):
-        buf = []
         # if size is unspecified, implementation-dependent
         # faasten now returns at most one block (4K) data
         if size is None:
             return self._blob_read()
         else:
+            buf = bytearray(b'')
             while size > 0:
                 data = self._blob_read(self.offset, size)
                 # reaches EOF
@@ -373,8 +390,7 @@ class Blob():
                 buf.extend(data)
                 self.offset += len(data)
                 size -= len(data)
-        # size = 0
-        return buf
+            return buf
 
     def tell(self):
         return self.offset

--- a/snapfaas/bins/admin_fstools/main.rs
+++ b/snapfaas/bins/admin_fstools/main.rs
@@ -4,10 +4,11 @@
 //! Kernels and runtime images are stored as blobs.
 
 use clap::{App, ArgGroup};
+use sha2::Sha256;
 use snapfaas::blobstore;
 use std::io::{Write, stdout};
 
-pub fn main() {
+pub fn main() -> std::io::Result<()> {
     env_logger::init();
     let matches = App::new("Faasten FS Admin Tools")
         .args_from_usage(
@@ -15,11 +16,14 @@ pub fn main() {
              --update_fsutil [PATH] 'PATH to updated fsutil image'
              --update_python [PATH] 'PATH to updated python image'
              --list          [PATH] 'PATH to a directory or a faceted directory, acting as [faasten]'
-             --read          [PATH] 'PATH to a file, acting as [faasten]'",
+             --faceted-list  [PATH] 'PATH to a directory or a faceted directory, acting as [faasten]'
+             --read          [PATH] 'PATH to a file, acting as [faasten]'
+             --blob          [PATH] [DEST] [LABEL]
+             --mkdir         [PATH] [LABEL]",
         )
         .group(
             ArgGroup::with_name("input")
-                .args(&["bootstrap", "update_fsutil", "update_python", "list", "read"])
+                .args(&["bootstrap", "update_fsutil", "update_python", "faceted-list", "list", "read", "blob", "mkdir"])
                 .required(true),
         )
         .get_matches();
@@ -40,6 +44,20 @@ pub fn main() {
             blobstore,
             matches.value_of("update_python").unwrap(),
         );
+    } else if matches.is_present("faceted-list") {
+        let clearance = labeled::buckle::Buckle::parse("faasten,T").unwrap();
+        snapfaas::fs::utils::set_my_privilge(snapfaas::fs::bootstrap::FAASTEN_PRIV.clone());
+        snapfaas::fs::utils::set_clearance(clearance);
+
+        let path = snapfaas::fs::path::Path::parse(matches.value_of("faceted-list").unwrap()).unwrap();
+        match snapfaas::fs::utils::faceted_list(&fs, path) {
+            Ok(entries) => {
+                for (name, dent) in entries {
+                    println!("{}\t{:?}", name, dent);
+                }
+            }
+            Err(e) => log::warn!("Failed list. {:?}", e),
+        }
     } else if matches.is_present("list") {
         let clearance = labeled::buckle::Buckle::parse("faasten,T").unwrap();
         snapfaas::fs::utils::set_my_privilge(snapfaas::fs::bootstrap::FAASTEN_PRIV.clone());
@@ -66,7 +84,28 @@ pub fn main() {
             }
             Err(e) => log::warn!("Failed read. {:?}", e),
         }
+    } else if matches.is_present("blob") {
+        snapfaas::fs::utils::set_my_privilge(snapfaas::fs::bootstrap::FAASTEN_PRIV.clone());
+
+        let mut args = matches.values_of("blob").unwrap();
+        let path = args.next().unwrap();
+        let mut file = std::fs::File::open(path)?;
+        let dest = snapfaas::fs::path::Path::parse(args.next().unwrap()).unwrap();
+        let label = labeled::buckle::Buckle::parse(args.next().unwrap()).unwrap();
+        let mut blobstore: blobstore::Blobstore<Sha256> = snapfaas::blobstore::Blobstore::default();
+        let mut blob = blobstore.create().unwrap();
+        let _ = std::io::copy(&mut file, &mut blob);
+        let blob = blobstore.save(blob).unwrap();
+        println!("{}", snapfaas::fs::utils::create_blob(&fs, dest.parent().unwrap(), dest.file_name().unwrap(), label, blob.name).is_ok());
+    } else if matches.is_present("mkdir") {
+        snapfaas::fs::utils::set_my_privilge(snapfaas::fs::bootstrap::FAASTEN_PRIV.clone());
+
+        let mut args = matches.values_of("mkdir").unwrap();
+        let dest = snapfaas::fs::path::Path::parse(args.next().unwrap()).unwrap();
+        let label = labeled::buckle::Buckle::parse(args.next().unwrap()).unwrap();
+        println!("{}", snapfaas::fs::utils::create_directory(&fs, dest.parent().unwrap(), dest.file_name().unwrap(), label).is_ok());
     } else {
         log::warn!("Noop.");
     }
+    Ok(())
 }

--- a/snapfaas/src/fs/mod.rs
+++ b/snapfaas/src/fs/mod.rs
@@ -830,7 +830,7 @@ impl<S: BackingStore> FS<S> {
                     match fdir_contents.get_facet(facet) {
                         Ok(dir) => return Ok(self.link(&dir, name.clone(), direntry.clone())?),
                         Err(FacetError::Unallocated) => {
-                            let dir = self.create_directory(current_label.borrow().clone());
+                            let dir = self.create_directory(facet.clone());
                             let _ = self.link(&dir, name.clone(), direntry.clone());
                             fdir_contents.append(dir);
                             let now = Instant::now();

--- a/snapfaas/src/fs/path.rs
+++ b/snapfaas/src/fs/path.rs
@@ -41,7 +41,6 @@ impl Path {
             &_ => (),
         }
 
-        let filename_re = regex::Regex::new(r"^([[:word:]]+\.)*[[:word:]]+$").unwrap();
         let label_re = regex::Regex::new(r"^<(?P<lbl>.+)>$").unwrap();
         for c in cs {
             if c == "%" {
@@ -54,11 +53,7 @@ impl Path {
                 let f = Buckle::parse(lblstr).map_err(|_| Error::InvalidFacet)?;
                 components.push(Component::Facet(f));
             } else {
-                if filename_re.is_match(c) {
-                    components.push(Component::Dscrp(c.to_string()));
-                } else {
-                    return Err(Error::InvalidName);
-                }
+                components.push(Component::Dscrp(c.to_string()));
             }
         }
         Ok(Self { components })

--- a/snapfaas/src/syscall_server.rs
+++ b/snapfaas/src/syscall_server.rs
@@ -460,6 +460,13 @@ impl SyscallProcessor {
                     let result = syscalls::ReadKeyResponse { value };
                     s.send(result.encode_to_vec())?;
                 }
+                Some(SC::FsOpenBlob(rd)) => {
+                    let value = fs::path::Path::parse(&rd.path)
+                        .ok()
+                        .and_then(|p| fs::utils::open_blob(&env.fs, p).ok());
+                    let result = syscalls::FsOpenBlobResponse { name: value };
+                    s.send(result.encode_to_vec())?;
+                }
                 Some(SC::FsList(req)) => {
                     let value = fs::path::Path::parse(&req.path).ok().and_then(|p| {
                         fs::utils::list(&env.fs, p)

--- a/snapfaas/src/syscalls.proto
+++ b/snapfaas/src/syscalls.proto
@@ -228,6 +228,14 @@ message FSCreateService {
   optional string headers = 6;
 }
 
+message FSOpenBlob {
+  string path = 1;
+}
+
+message FSOpenBlobResponse {
+  optional string name = 1;
+}
+
 message Syscall {
   oneof syscall {
     Response response = 1;
@@ -258,5 +266,6 @@ message Syscall {
     FSCreateRedirectGate fsCreateRedirectGate = 30;
     FSCreateService fsCreateService = 31;
     InvokeService invokeService = 32;
+    FSOpenBlob fsOpenBlob = 33;
   }
 }


### PR DESCRIPTION
This PR contains a number of small nits found in the process of getting benchmarks working

1. Add `mkdir` and `blob` commands to `admin_fstools` to allow creating a directory and uploading a blob, respectively, to the datastore during bootstrap (e.g. to setup input files and output directories for benchmarking).
2. Fix a bug in linking facets that created the wrong facet
3. Add `seek` and `tell` operations to the python's `Blob` class so it can behave like a file in more cases
4. Get rid of the absolute path in the example bootstrap config.
5. Add an `FSOpenBlob` system call for retrieving a blob name by its file name