### PR TITLE
Remove unused GitHub built-in functionality

### DIFF
--- a/frontends/webfront/src/main.rs
+++ b/frontends/webfront/src/main.rs
@@ -9,9 +9,6 @@ fn main() -> Result<(), std::io::Error> {
     dotenv::dotenv().ok();
     env_logger::init();
 
-    let github_client_id = std::env::var("GITHUB_CLIENT_ID").expect("client id");
-    let github_client_secret = std::env::var("GITHUB_CLIENT_SECRET").expect("client secret");
-
     let matches = App::new("SnapFaaS API Web Server")
         .arg(
             Arg::with_name("storage path")
@@ -106,10 +103,6 @@ fn main() -> Result<(), std::io::Error> {
     );
     let fs = snapfaas::fs::FS::new(&*dbenv);
     let app = app::App::new(
-        app::GithubOAuthCredentials {
-            client_id: github_client_id,
-            client_secret: github_client_secret,
-        },
         PKey::private_key_from_pem(private_key_bytes.as_slice()).unwrap(),
         PKey::public_key_from_pem(public_key_bytes.as_slice()).unwrap(),
         blobstore,

--- a/snapfaas/src/syscalls.proto
+++ b/snapfaas/src/syscalls.proto
@@ -94,18 +94,6 @@ enum HttpVerb {
   DELETE = 4;
 }
 
-message GithubRest {
-  HttpVerb verb = 1;
-  string route = 2;
-  optional string body = 3;
-  bool toblob = 4;
-}
-
-message GithubRestResponse {
-  bytes data = 1;
-  uint32 status = 2;
-}
-
 message GetCurrentLabel {
 }
 
@@ -245,7 +233,6 @@ message Syscall {
     Response response = 1;
     GetCurrentLabel getCurrentLabel = 4;
     Buckle taintWithLabel = 5;
-    GithubRest githubRest = 6;
     InvokeGate invokeGate = 7;
     FSRead fsRead = 8;
     FSWrite fsWrite = 9;


### PR DESCRIPTION
We're not using these APIs anymore, and don't intend to revive them in this form. They currently make deploying significantly more cumbersome than necessary, so let's get rid of them.