### PR TITLE
Add label to TaskReturn and check label in gateway

### DIFF
--- a/snapfaas/src/sched/messages.proto
+++ b/snapfaas/src/sched/messages.proto
@@ -94,4 +94,5 @@ enum ReturnCode {
 message TaskReturn {
     ReturnCode code = 1;
     optional string payload = 2;
+    syscalls.Buckle label = 3;
 }

--- a/snapfaas/src/sched/rpc_server.rs
+++ b/snapfaas/src/sched/rpc_server.rs
@@ -4,6 +4,9 @@ use std::net::{TcpListener, TcpStream};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 
+use crate::fs;
+use crate::syscall_server::buckle_to_pblabel;
+
 use super::message;
 use super::resource_manager::ResourceManager;
 use super::rpc::ResourceInfo;
@@ -97,6 +100,7 @@ impl RpcServer {
                             let ret = message::TaskReturn {
                                 code: message::ReturnCode::QueueFull as i32,
                                 payload: None,
+                                label: Some(buckle_to_pblabel(&fs::utils::get_current_label())),
                             };
                             let _ = message::write(&mut stream, &ret);
                         }
@@ -123,6 +127,7 @@ impl RpcServer {
                             let ret = message::TaskReturn {
                                 code: message::ReturnCode::QueueFull as i32,
                                 payload: None,
+                                label: Some(buckle_to_pblabel(&fs::utils::get_current_label())),
                             };
                             let _ = message::write(&mut stream, &ret);
                         }

--- a/snapfaas/src/syscall_server.rs
+++ b/snapfaas/src/syscall_server.rs
@@ -183,6 +183,7 @@ impl SyscallProcessor {
                     return Ok(TaskReturn {
                         code: ReturnCode::Success as i32,
                         payload: Some(r.payload),
+                        label: Some(buckle_to_pblabel(&fs::utils::get_current_label())),
                     });
                 }
                 Some(SC::InvokeGate(i)) => {

--- a/snapfaas/src/worker.rs
+++ b/snapfaas/src/worker.rs
@@ -13,7 +13,7 @@ use log::{debug, error};
 use crate::configs::FunctionConfig;
 use crate::vm::Vm;
 //use crate::metrics::{self, WorkerMetrics};
-use crate::fs::{Function, FS, BackingStore};
+use crate::fs::{Function, FS, BackingStore, self};
 use crate::resource_manager;
 use crate::sched::{
     self,
@@ -123,6 +123,7 @@ impl<B: BackingStore> Worker<B> {
                                 let mut ret = TaskReturn {
                                     code: ReturnCode::ProcessRequestFailed as i32,
                                     payload: None,
+                                    label: Some(buckle_to_pblabel(&fs::utils::get_current_label())),
                                 };
                                 loop {
                                     cnt += 1;
@@ -191,6 +192,7 @@ impl<B: BackingStore> Worker<B> {
                                 let ret = TaskReturn {
                                     code: ReturnCode::ResourceExhausted as i32,
                                     payload: None,
+                                    label: Some(buckle_to_pblabel(&fs::utils::get_current_label())),
                                 };
                                 if let Err(e) = sched::rpc::finish(
                                     &mut self.env.sched_conn.as_mut().unwrap(),
@@ -219,6 +221,7 @@ impl<B: BackingStore> Worker<B> {
                                 let mut ret = TaskReturn {
                                     code: ReturnCode::ProcessRequestFailed as i32,
                                     payload: None,
+                                    label: Some(buckle_to_pblabel(&fs::utils::get_current_label())),
                                 };
                                 loop {
                                     cnt += 1;
@@ -282,6 +285,7 @@ impl<B: BackingStore> Worker<B> {
                                 let ret = TaskReturn {
                                     code: ReturnCode::ResourceExhausted as i32,
                                     payload: None,
+                                    label: Some(buckle_to_pblabel(&fs::utils::get_current_label())),
                                 };
                                 if let Err(e) = sched::rpc::finish(
                                     &mut self.env.sched_conn.as_mut().unwrap(),


### PR DESCRIPTION
The scheduler always returns the current label at the point of return and the gateway also uses the thread's current label (which is set in `init`) as the guard.