### PR TITLE
Bump clap to 4.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,11 +362,47 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.16.0",
+]
+
+[[package]]
+name = "clap"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
+ "strsim 0.10.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -328,6 +413,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "cmake"
@@ -347,6 +438,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-foundation"
@@ -1260,6 +1357,18 @@ name = "ipnet"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix 0.37.19",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "itertools"
@@ -2616,7 +2725,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "cgroups",
- "clap 2.34.0",
+ "clap 4.2.7",
  "crossbeam",
  "ctrlc",
  "env_logger",
@@ -3154,6 +3263,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,24 +349,9 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags",
- "clap_lex 0.2.4",
- "indexmap",
- "strsim 0.10.0",
- "termcolor",
- "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -389,7 +374,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "bitflags",
- "clap_lex 0.4.1",
+ "clap_lex",
  "strsim 0.10.0",
 ]
 
@@ -403,15 +388,6 @@ dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -1845,12 +1821,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
-
-[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,12 +2850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3465,7 +3429,7 @@ name = "webfront"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "clap 3.2.25",
+ "clap 4.2.7",
  "dotenv",
  "env_logger",
  "github-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,12 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dumbo"
 version = "0.1.0"
 source = "git+https://github.com/princeton-sns/firecracker?rev=37f177869aecc5167b3b9b188ef907d171b59bfb#37f177869aecc5167b3b9b188ef907d171b59bfb"
@@ -3430,7 +3424,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap 4.2.7",
- "dotenv",
  "env_logger",
  "github-types",
  "jwt",

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ pkgs.rust_1_66.packages.stable.buildRustPackages.rustPlatform.buildRustPackage r
 
   src = ./.;
 
-  cargoSha256 = "sha256-Vj8GQkAAl2HsLUx+Dgq+BGhJoZETKhUmx7A9JHOlKwc=";
+  cargoSha256 = "sha256-fgDOFcDkOojmbYpdzLVUpWeOz9wQNm0FMNzoB7JsXrY=";
 
   nativeBuildInputs = [ pkgs.perl pkgs.openssl pkgs.pkg-config pkgs.protobuf pkgs.unzip pkgs.cmake ];
 

--- a/frontends/webfront/Cargo.toml
+++ b/frontends/webfront/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.9.1"
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_warn"] }
 dotenv = "0.15.0"
 chrono = "0.4.22"
-clap = "^3.2.22"
+clap = "4.2.7"
 reqwest = { version = "*", features = [ "blocking", "json", "multipart" ] }
 github-types = "0.1.1"
 rouille = "=3.5.0"

--- a/frontends/webfront/Cargo.toml
+++ b/frontends/webfront/Cargo.toml
@@ -12,7 +12,6 @@ serde_yaml = "*"
 serde_json = "*"
 env_logger = "0.9.1"
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_warn"] }
-dotenv = "0.15.0"
 chrono = "0.4.22"
 clap = "4.2.7"
 reqwest = { version = "*", features = [ "blocking", "json", "multipart" ] }

--- a/frontends/webfront/src/main.rs
+++ b/frontends/webfront/src/main.rs
@@ -34,7 +34,6 @@ struct Cli {
 }
 
 fn main() -> Result<(), std::io::Error> {
-    dotenv::dotenv().ok();
     env_logger::init();
 
     let cli = Cli::parse();

--- a/snapfaas/Cargo.toml
+++ b/snapfaas/Cargo.toml
@@ -28,17 +28,17 @@ path = "bins/garbage-collector/main.rs"
 #name = "sfclient"
 #path = "bins/sfclient/main.rs"
 
-[[bin]]
-name = "sfdb"
-path = "bins/sfdb/main.rs"
+#[[bin]]
+#name = "sfdb"
+#path = "bins/sfdb/main.rs"
 
 #[[bin]]
 #name = "sffs"
 #path = "bins/sffs/main.rs"
 
-[[bin]]
-name = "sfblob"
-path = "bins/sfblob/main.rs"
+#[[bin]]
+#name = "sfblob"
+#path = "bins/sfblob/main.rs"
 
 [[bin]]
 name = "admin_fstools"
@@ -56,7 +56,7 @@ byteorder = ">=1.2.1"
 prost = "0.9.0"
 lmdb-rkv = "0.14.0"
 url = "2.2"
-clap = "2.33.0"
+clap = { version = "4.2.7", features = ["derive"] }
 log ={ version = "0.4", features = ["max_level_debug", "release_max_level_warn"] }
 env_logger = "^0.9.0"
 serde = {version = "1.0.102", features = ["derive"]}

--- a/snapfaas/bins/firerunner/main.rs
+++ b/snapfaas/bins/firerunner/main.rs
@@ -1,240 +1,63 @@
-#[macro_use(crate_version, crate_authors)]
-extern crate clap;
-extern crate cgroups;
-
 use std::fs::File;
-use std::path::PathBuf;
-use std::io::{BufReader};
-use std::time::Instant;
+use std::io::BufReader;
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::time::Instant;
 
+use memory_model::MemoryFileOption;
+use net_util::MacAddr;
 use vmm::vmm_config::boot_source::BootSourceConfig;
 use vmm::vmm_config::drive::BlockDeviceConfig;
-use vmm::vmm_config::net::NetworkInterfaceConfig;
-use net_util::MacAddr;
-use vmm::vmm_config::vsock::VsockDeviceConfig;
 use vmm::vmm_config::machine_config::VmConfig;
+use vmm::vmm_config::net::NetworkInterfaceConfig;
+use vmm::vmm_config::vsock::VsockDeviceConfig;
 use vmm::SnapFaaSConfig;
-use memory_model::MemoryFileOption;
 
-use clap::{App, Arg};
+use clap::Parser;
 
+use snapfaas::cli;
 use snapfaas::firecracker_wrapper::VmmWrapper;
+
+#[derive(Parser)]
+struct Cli {
+    #[command(flatten)]
+    vmconfig: cli::VmConfig,
+}
 
 fn main() {
     let mut ts_vec = Vec::with_capacity(10);
     ts_vec.push(Instant::now());
-    let cmd_arguments = App::new("firecracker")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about("launch a microvm.")
-        .arg(
-            Arg::with_name("kernel")
-                .short("k")
-                .long("kernel")
-                .value_name("kernel")
-                .takes_value(true)
-                .required(true)
-                .help("path the the kernel binary")
-        )
-        .arg(
-            Arg::with_name("kernel_args")
-                .short("c")
-                .long("kernel_args")
-                .value_name("kernel_args")
-                .takes_value(true)
-                .required(false)
-                .default_value(vmm::DEFAULT_KERNEL_CMDLINE)
-                .help("kernel boot args")
-        )
-        .arg(
-            Arg::with_name("rootfs")
-                .short("r")
-                .long("rootfs")
-                .value_name("rootfs")
-                .takes_value(true)
-                .required(true)
-                .help("path to the root file system")
-        )
-        .arg(
-            Arg::with_name("appfs")
-                .long("appfs")
-                .value_name("appfs")
-                .takes_value(true)
-                .required(false)
-                .help("path to the root file system")
-        )
-        .arg(
-            Arg::with_name("id")
-                .long("id")
-                .help("microvm unique identifier")
-                .default_value("abcde1234")
-                .required(true)
-                .takes_value(true)
-        )
-        .arg(
-            Arg::with_name("load_dir")
-                .long("load_from")
-                .takes_value(true)
-                .required(false)
-                .help("if specified start vm from a snapshot under the given directory")
-        )
-        .arg(
-            Arg::with_name("dump_dir")
-                .long("dump_to")
-                .takes_value(true)
-                .required(false)
-                .help("if specified creates a snapshot right after runtime is up under the given directory")
-        )
-        .arg(
-            Arg::with_name("mem_size")
-                 .long("mem_size")
-                 .value_name("MEMSIZE")
-                 .takes_value(true)
-                 .required(true)
-                 .help("Guest memory size in MB (default is 128)")
-        )
-        .arg(
-            Arg::with_name("vcpu_count")
-                 .long("vcpu_count")
-                 .value_name("VCPUCOUNT")
-                 .takes_value(true)
-                 .required(true)
-                 .help("Number of vcpus (default is 1)")
-        )
-        .arg(
-            Arg::with_name("copy_base_memory")
-                 .long("copy_base")
-                 .value_name("COPYBASE")
-                 .takes_value(false)
-                 .required(false)
-                 .help("Restore base snapshot memory by copying")
-        )
-        .arg(
-            Arg::with_name("copy_diff_memory")
-                 .long("copy_diff")
-                 .value_name("COPYDIFF")
-                 .takes_value(false)
-                 .required(false)
-                 .help("If a diff snapshot is provided, restore its memory by copying")
-        )
-        .arg(
-            Arg::with_name("mac")
-                 .long("mac")
-                 .value_name("MAC")
-                 .takes_value(true)
-                 .required(false)
-                 .help("configure a network device for the VM with the provided MAC address")
-        )
-        .arg(
-            Arg::with_name("tap_name")
-                 .long("tap_name")
-                 .value_name("TAPNAME")
-                 .takes_value(true)
-                 .required(false)
-                 .help("configure a network device for the VM backed by the provided tap device")
-        )
-        .arg(
-            Arg::with_name("vsock cid")
-                .long("cid")
-                .value_name("CID")
-                .takes_value(true)
-                .required(false)
-                .help("vsock cid of the guest VM")
-        )
-        .arg(
-            // by default base snapshot is not opened with O_DIRECT
-            Arg::with_name("odirect base")
-                .long("odirect_base")
-                .value_name("ODIRECT_BASE")
-                .takes_value(false)
-                .required(false)
-                .help("If present, open base snapshot's memory file with O_DIRECT")
-        )
-        .arg(
-            // by default diff snapshot is opened with O_DIRECT
-            Arg::with_name("no odirect diff")
-                .long("no_odirect_diff")
-                .value_name("NO_ODIRECT_DIFF")
-                .takes_value(false)
-                .required(false)
-                .help("If present, open diff snapshot's memory file without O_DIRECT")
-        )
-        .arg(
-            Arg::with_name("no odirect rootfs")
-                .long("no_odirect_root")
-                .value_name("NO_ODIRECT_ROOT")
-                .takes_value(false)
-                .required(false)
-                .help("If present, open rootfs file without O_DIRECT")
-        )
-        .arg(
-            Arg::with_name("no odirect appfs")
-                .long("no_odirect_app")
-                .value_name("NO_ODIRECT_APP")
-                .takes_value(false)
-                .required(false)
-                .help("If present, open appfs file without O_DIRECT")
-        )
-        .arg(
-            Arg::with_name("dump working set")
-                .long("dump_ws")
-                .value_name("DUMP_WS")
-                .takes_value(false)
-                .required(false)
-                .help("If present, VMM will send `dump working set` action to the VM when the host signals through the unix socket connection")
-        )
-        .arg(
-            Arg::with_name("load working set")
-                .long("load_ws")
-                .value_name("LOAD_WS")
-                .takes_value(false)
-                .required(false)
-                .help("If present, VMM will load the regions contained in diff_dirs[0]/WS only effective when there is one diff snapshot.")
-        )
-        .get_matches();
+
+    let args = Cli::parse().vmconfig;
 
     // process command line arguments
-    let instance_id = cmd_arguments.value_of("id").expect("id doesn't exist").to_string();
-    let kernel = cmd_arguments
-                .value_of("kernel")
-                .map(PathBuf::from)
-                .expect("path to kernel image not specified");
-    let rootfs = cmd_arguments
-                .value_of("rootfs")
-                .map(PathBuf::from)
-                .expect("path to rootfs not specified");
-
-    let kargs = cmd_arguments
-                .value_of("kernel_args")
-                .expect("kernel boot argument not specified")
-                .to_string();
-    let mem_size_mib = cmd_arguments
-                .value_of("mem_size")
-                .map(|x| x.parse::<usize>().expect("Invalid VM mem size"))
-                .expect("VM mem size not specified");
-    let vcpu_count = cmd_arguments
-                .value_of("vcpu_count")
-                .map(|x| x.parse::<u64>().expect("Invalid vcpu count"))
-                .expect("vcpu count not specified");
+    let instance_id = args.id;
+    let kernel = PathBuf::from(args.kernel);
+    let rootfs = PathBuf::from(args.rootfs);
+    let kargs = args.kernel_args;
+    let mem_size_mib = args.memory as usize;
+    let vcpu_count = args.vcpu as usize;
 
     // optional arguments:
-    let appfs = cmd_arguments.value_of("appfs").map(PathBuf::from);
-    let dump_dir: Option<PathBuf> = cmd_arguments.value_of("dump_dir").map(PathBuf::from);
-    let load_dir = cmd_arguments.value_of("load_dir").map_or(Vec::new(), |x| x.split(',').collect::<Vec<&str>>()
-        .iter().map(PathBuf::from).collect());
-    let copy_base = cmd_arguments.is_present("copy_base_memory");
-    let copy_diff = cmd_arguments.is_present("copy_diff_memory");
-    let odirect_base = cmd_arguments.is_present("odirect base");
-    let odirect_diff = !cmd_arguments.is_present("no odirect diff");
-    let odirect_rootfs = !cmd_arguments.is_present("no odirect rootfs");
-    let odirect_appfs = !cmd_arguments.is_present("no odirect appfs");
-    let load_ws = cmd_arguments.is_present("load working set");
-    let mac = cmd_arguments.value_of("mac").map(|x| x.to_string());
-    let tap_name = cmd_arguments.value_of("tap_name").map(|x| x.to_string());
-    assert!(tap_name.is_none() == mac.is_none());
-    let cid = cmd_arguments.value_of("vsock cid")
-        .map(|x| x.parse::<u32>().expect("Invalid cid"));
+    let appfs = args.appfs.map(PathBuf::from);
+    let dump_dir = args.dump_dir.map(PathBuf::from);
+    let load_dir = args.load_dir.map_or(Vec::new(), |x| {
+        x.split(',')
+            .collect::<Vec<&str>>()
+            .iter()
+            .map(PathBuf::from)
+            .collect()
+    });
+    let copy_base = args.copy_base_memory;
+    let copy_diff = args.copy_diff_memory;
+    let odirect_base = args.odirect_base;
+    let odirect_diff = !args.no_odirect_diff;
+    let odirect_rootfs = !args.no_odirect_root;
+    let odirect_appfs = !args.no_odirect_app;
+    let load_ws = args.load_ws;
+    let mac = args.mac;
+    let tap_name = args.tap;
+    let cid = args.vsock_cid;
 
     // Make sure kernel, rootfs, appfs, load_dir, dump_dir exist
     if !&kernel.exists() {
@@ -246,12 +69,12 @@ fn main() {
         std::process::exit(1);
     }
 
-    if appfs.is_some() && !appfs.as_ref().unwrap().exists(){
+    if appfs.is_some() && !appfs.as_ref().unwrap().exists() {
         eprintln!("appfs not exist");
         std::process::exit(1);
     }
 
-    if dump_dir.is_some() && !dump_dir.as_ref().unwrap().exists(){
+    if dump_dir.is_some() && !dump_dir.as_ref().unwrap().exists() {
         eprintln!("dump directory not exist");
         std::process::exit(1);
     }
@@ -283,12 +106,18 @@ fn main() {
         load_dir,
         dump_dir,
         huge_page: false,
-        base: MemoryFileOption { copy: copy_base, odirect: odirect_base},
-        diff: MemoryFileOption { copy: copy_diff, odirect: odirect_diff},
+        base: MemoryFileOption {
+            copy: copy_base,
+            odirect: odirect_base,
+        },
+        diff: MemoryFileOption {
+            copy: copy_diff,
+            odirect: odirect_diff,
+        },
         load_ws,
     };
     // Create vmm thread
-    let mut vmm = match VmmWrapper::new(instance_id.clone(), config) {
+    let mut vmm = match VmmWrapper::new(instance_id.to_string(), config) {
         Ok(vmm) => vmm,
         Err(e) => {
             eprintln!("Vmm failed to start due to: {:?}", e);
@@ -301,7 +130,7 @@ fn main() {
     // exit code 1. When exit happens before sending the Ready Signal, whoever
     // is listening on the stdout of this process for a ready signal will
     // receive 0.
-    let machine_config = VmConfig{
+    let machine_config = VmConfig {
         vcpu_count: Some(vcpu_count as u8),
         mem_size_mib: Some(mem_size_mib),
         ..Default::default()
@@ -315,7 +144,7 @@ fn main() {
     if !from_snapshot {
         let boot_config = BootSourceConfig {
             kernel_image_path: kernel.to_str().expect("kernel path None").to_string(),
-            boot_args: Some(kargs),
+            boot_args: kargs,
         };
 
         if let Err(e) = vmm.set_boot_source(boot_config) {
@@ -347,7 +176,7 @@ fn main() {
             is_read_only: true,
             partuuid: None,
             rate_limiter: None,
-                odirect: odirect_appfs,
+            odirect: odirect_appfs,
         };
         if let Err(e) = vmm.insert_block_device(block_config) {
             eprintln!("Vmm failed to insert appfs due to: {:?}", e);
@@ -371,20 +200,18 @@ fn main() {
         }
     }
 
-    if let Some(cid) = cid.clone() {
-        let vsock_path = format!("worker-{}.sock", cid);
-        let _ = std::fs::remove_file(&vsock_path);
-        let vsock_config = VsockDeviceConfig {
-            vsock_id: "vsock0".to_string(),
-            guest_cid: cid,
-            uds_path: vsock_path.to_string(),
-        };
-        if let Err(e) = vmm.add_vsock(vsock_config) {
-            eprintln!("Vmm failed to add vsock due to: {:?}", e);
-            std::process::exit(1);
-        }
+    let vsock_path = format!("worker-{}.sock", cid);
+    let _ = std::fs::remove_file(&vsock_path);
+    let vsock_config = VsockDeviceConfig {
+        vsock_id: "vsock0".to_string(),
+        guest_cid: cid,
+        uds_path: vsock_path.to_string(),
+    };
+    if let Err(e) = vmm.add_vsock(vsock_config) {
+        eprintln!("Vmm failed to add vsock due to: {:?}", e);
+        std::process::exit(1);
     }
- 
+
     ts_vec.push(Instant::now());
     //TODO: Optionally add a logger
 
@@ -395,20 +222,21 @@ fn main() {
     }
 
     // listen for dump working set
-    if cmd_arguments.is_present("dump working set") {
+    if args.dump_ws {
         let listener_port = format!("dump_ws-{}.sock", instance_id);
-        let unix_sock_listener = UnixListener::bind(listener_port).expect("Failed to bind to unix listener");
-         match unix_sock_listener.accept() {
+        let unix_sock_listener =
+            UnixListener::bind(listener_port).expect("Failed to bind to unix listener");
+        match unix_sock_listener.accept() {
             Ok((_, _)) => match vmm.dump_working_set() {
                 Ok(_) => {
                     eprintln!("VMM: dumped the working set.");
                     let port = format!("dump_ws-{}.sock.back", instance_id);
                     UnixStream::connect(port).expect("Failed to connect");
-                },
+                }
                 Err(e) => {
                     eprintln!("VMM: failed to dump the working set: {:?}", e);
                     std::process::exit(1);
-                },
+                }
             },
             Err(e) => {
                 eprintln!("VMM: failed to dump the working set: {:?}", e);
@@ -417,9 +245,11 @@ fn main() {
         }
     };
     let parse_time = ts_vec[2].duration_since(ts_vec[1]).as_micros();
-    eprintln!("FR: Parse JSON: {} us\nFR: Preconfigure VM: {} us",
-             parse_time,
-             ts_vec[3].duration_since(ts_vec[0]).as_micros() - parse_time);
+    eprintln!(
+        "FR: Parse JSON: {} us\nFR: Preconfigure VM: {} us",
+        parse_time,
+        ts_vec[3].duration_since(ts_vec[0]).as_micros() - parse_time
+    );
     vmm.join_vmm();
     std::process::exit(0);
 }

--- a/snapfaas/bins/singlevm/main.rs
+++ b/snapfaas/bins/singlevm/main.rs
@@ -1,278 +1,84 @@
-#[macro_use(crate_version, crate_authors)]
-extern crate clap;
+//! This binary is used to launch a single instance of firerunner
+//! It reads a request from stdin, launches a VM based on cmdline inputs, sends
+//! the request to VM, waits for VM's response and finally prints the response
+//! to stdout, kills the VM and exits.
 use labeled::buckle::{self, Buckle};
-use log::{debug, error, warn};
+use log::{debug, error};
 use snapfaas::blobstore::Blobstore;
+use snapfaas::cli;
 use snapfaas::configs::FunctionConfig;
-use snapfaas::fs::lmdb::DBENV;
 use snapfaas::fs::tikv::TikvClient;
-use snapfaas::fs::{FS, BackingStore};
+use snapfaas::fs::{BackingStore, FS};
 use snapfaas::syscall_server::SyscallGlobalEnv;
-/// This binary is used to launch a single instance of firerunner
-/// It reads a request from stdin, launches a VM based on cmdline inputs, sends
-/// the request to VM, waits for VM's response and finally prints the response
-/// to stdout, kills the VM and exits.
 use snapfaas::vm::Vm;
 use snapfaas::{syscall_server, unlink_unix_sockets};
 use std::io::BufRead;
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::time::Instant;
 use std::sync::Arc;
+use std::time::Instant;
 
-use clap::{App, Arg};
+use clap::Parser;
 
-const CID: u32 = 100;
-// If firerunner path is not set by the user, the program will assume firerunner is on the
-// environment variable PATH.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[command(flatten)]
+    vmconfig: cli::VmConfig,
+    /// If present, force singlevm to exit once firerunner exits
+    #[arg(long, requires = "dump_snapshot")]
+    force_exit: bool,
+    /// Faasten ID
+    #[arg(long)]
+    login: Option<String>,
+    /// Buckle label that the VM starts with
+    #[arg(long, value_name = "BUCKLE")]
+    start_label: Option<String>,
+    #[command(flatten)]
+    store: cli::Store,
+}
 
 fn main() {
     env_logger::init();
-    let cmd_arguments = App::new("fireruner wrapper")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about("launch a single firerunner vm.")
-        .arg(
-            Arg::with_name("kernel")
-                .short("k")
-                .long("kernel")
-                .value_name("kernel")
-                .takes_value(true)
-                .required(true)
-                .help("path the the kernel binary")
-        )
-        .arg(
-            Arg::with_name("kernel_args")
-                .short("c")
-                .long("kernel_args")
-                .value_name("kernel_args")
-                .takes_value(true)
-                .required(false)
-                .help("kernel boot args")
-        )
-        .arg(
-            Arg::with_name("rootfs")
-                .short("r")
-                .long("rootfs")
-                .value_name("rootfs")
-                .takes_value(true)
-                .required(true)
-                .help("path to the root file system")
-        )
-        .arg(
-            Arg::with_name("appfs")
-                .long("appfs")
-                .value_name("appfs")
-                .takes_value(true)
-                .required(false)
-                .help("path to the app file system")
-        )
-        .arg(
-            Arg::with_name("login")
-                .long("login")
-                .value_name("LOGIN")
-                .takes_value(true)
-                .required(false)
-                .help("if specified acting as the passed in identity.")
-        )
-        .arg(
-            Arg::with_name("secrecy")
-                .long("secrecy")
-                .value_name("BUCKLE SECRECY STRING")
-                .takes_value(true)
-                .required(false)
-                .help("if specified VM starts with the secrecy.")
-        )
-        .arg(
-            Arg::with_name("id")
-                .long("id")
-                .help("microvm unique identifier")
-                .default_value("1234")
-                .required(true)
-                .takes_value(true)
-        )
-        .arg(
-            Arg::with_name("load_dir")
-                .long("load_dir")
-                .takes_value(true)
-                .required(false)
-                .help("if specified start vm from a snapshot under the given directory")
-        )
-        .arg(
-            Arg::with_name("dump_dir")
-                .long("dump_dir")
-                .takes_value(true)
-                .required(false)
-                .help("if specified creates a snapshot right after runtime is up under the given directory")
-        )
-        .arg(
-            Arg::with_name("mem_size")
-                 .long("mem_size")
-                 .value_name("MB")
-                 .default_value("128")
-                 .help("Guest memory size in MB (default is 128)")
-        )
-        .arg(
-            Arg::with_name("vcpu_count")
-                 .long("vcpu_count")
-                 .value_name("VCPUCOUNT")
-                 .default_value("1")
-                 .help("Number of vcpus (default is 1)")
-        )
-        .arg(
-            Arg::with_name("copy_base_memory")
-                 .long("copy_base")
-                 .value_name("COPYBASE")
-                 .takes_value(false)
-                 .required(false)
-                 .help("Restore base snapshot memory by copying")
-        )
-        .arg(
-            Arg::with_name("copy_diff_memory")
-                 .long("copy_diff")
-                 .takes_value(false)
-                 .required(false)
-                 .help("If a diff snapshot is provided, restore its memory by copying")
-        )
-        .arg(
-            Arg::with_name("enable network")
-                .long("network")
-                .takes_value(false)
-                .required(false)
-                .help("enable newtork through tap device `tap0`")
-        )
-        //.arg(
-        //    Arg::with_name("firerunner")
-        //        .long("firerunner")
-        //        .value_name("PATH_TO_FIRERUNNER")
-        //        .default_value(DEFAULT_FIRERUNNER)
-        //        .help("path to the firerunner binary")
-        //)
-        .arg(
-            Arg::with_name("force exit")
-                .long("force_exit")
-                .value_name("FORCEEXIT")
-                .takes_value(false)
-                .required(false)
-                .help("force fc_wrapper to exit once firerunner exits")
-        )
-        .arg(
-            // by default base snapshot is not opened with O_DIRECT
-            Arg::with_name("odirect base")
-                .long("odirect_base")
-                .value_name("ODIRECT_BASE")
-                .takes_value(false)
-                .required(false)
-                .help("If present, open base snapshot's memory file with O_DIRECT")
-        )
-        .arg(
-            // by default diff snapshot is opened with O_DIRECT
-            Arg::with_name("no odirect diff")
-                .long("no_odirect_diff")
-                .value_name("NO_ODIRECT_DIFF")
-                .takes_value(false)
-                .required(false)
-                .help("If present, open diff snapshot's memory file without O_DIRECT")
-        )
-        .arg(
-            Arg::with_name("no odirect rootfs")
-                .long("no_odirect_root")
-                .value_name("NO_ODIRECT_ROOT")
-                .takes_value(false)
-                .required(false)
-                .help("If present, open rootfs file without O_DIRECT")
-        )
-        .arg(
-            Arg::with_name("no odirect appfs")
-                .long("no_odirect_app")
-                .value_name("NO_ODIRECT_APP")
-                .takes_value(false)
-                .required(false)
-                .help("If present, open appfs file without O_DIRECT")
-        )
-        .arg(
-            Arg::with_name("dump working set")
-                .long("dump_ws")
-                .value_name("DUMP_WS")
-                .takes_value(false)
-                .required(false)
-                .help("If present, VMM will send `dump working set` action to the VM when the host signals through the unix socket connection. The value is the directory to put the working set in")
-        )
-        .arg(
-            Arg::with_name("load working set")
-                .long("load_ws")
-                .value_name("LOAD_WS")
-                .takes_value(false)
-                .required(false)
-                .help("If present, VMM will load the regions contained in diff_dirs[0]/WS only effective when there is one diff snapshot.")
-        )
-        .arg(
-            Arg::with_name("tikv proxies")
-                .long("tikv")
-                .value_name("[ADDR:]PORT")
-                .takes_value(true)
-                .required(false)
-                .help("One or more addresses of TiKV placement driver, separated by space.")
-        )
-        .get_matches();
 
-    if cmd_arguments.is_present("enable network") {
-        // warn if tap0 is missing the program will hang
-        warn!("Network turned on. Tap device `tap0` must be present.");
-    }
+    let cli = Cli::parse();
 
     // Create a FunctionConfig value based on cmdline inputs
     let vm_app_config = FunctionConfig {
-        network: cmd_arguments.is_present("enable network"),
-        runtimefs: cmd_arguments
-            .value_of("rootfs")
-            .expect("rootfs")
-            .to_string(),
-        appfs: cmd_arguments.value_of("appfs").map(|s| s.to_string()),
-        vcpus: cmd_arguments
-            .value_of("vcpu_count")
-            .expect("vcpu")
-            .parse::<u64>()
-            .expect("vcpu not int"),
-        memory: cmd_arguments
-            .value_of("mem_size")
-            .expect("mem_size")
-            .parse::<usize>()
-            .expect("mem_size not int"),
+        mac: cli.vmconfig.mac,
+        tap: cli.vmconfig.tap,
+        runtimefs: cli.vmconfig.rootfs,
+        appfs: cli.vmconfig.appfs,
+        vcpus: cli.vmconfig.vcpu as u64,
+        memory: cli.vmconfig.memory as usize,
         concurrency_limit: 1,
-        load_dir: cmd_arguments.value_of("load_dir").map(|s| s.to_string()),
-        dump_dir: cmd_arguments.value_of("dump_dir").map(|s| s.to_string()),
-        copy_base: cmd_arguments.is_present("copy_base_memory"),
-        copy_diff: cmd_arguments.is_present("copy_diff_memory"),
-        kernel: cmd_arguments
-            .value_of("kernel")
-            .expect("kernel")
-            .to_string(),
-        cmdline: cmd_arguments.value_of("kernel_args").map(|s| s.to_string()),
-        dump_ws: cmd_arguments.is_present("dump working set"),
-        load_ws: cmd_arguments.is_present("load working set"),
+        load_dir: cli.vmconfig.load_dir,
+        dump_dir: cli.vmconfig.dump_dir,
+        copy_base: cli.vmconfig.copy_base_memory,
+        copy_diff: cli.vmconfig.copy_diff_memory,
+        kernel: cli.vmconfig.kernel,
+        cmdline: cli.vmconfig.kernel_args,
+        dump_ws: cli.vmconfig.dump_ws,
+        load_ws: cli.vmconfig.load_ws,
     };
-    let id = cmd_arguments
-        .value_of("id")
-        .unwrap()
-        .parse::<usize>()
-        .unwrap();
+
+    let id = cli.vmconfig.id as usize;
     let odirect = snapfaas::vm::OdirectOption {
-        base: cmd_arguments.is_present("odirect base"),
-        diff: !cmd_arguments.is_present("no odirect diff"),
-        rootfs: !cmd_arguments.is_present("no odirect rootfs"),
-        appfs: !cmd_arguments.is_present("no odirect appfs"),
+        base: cli.vmconfig.odirect_base,
+        diff: cli.vmconfig.no_odirect_diff,
+        rootfs: cli.vmconfig.no_odirect_root,
+        appfs: cli.vmconfig.no_odirect_app,
     };
 
     // Launch a vm based on the FunctionConfig value
     let t1 = Instant::now();
     let mut vm = Vm::new(id, vm_app_config.clone().into());
-    let vm_listener_path = format!("worker-{}.sock_1234", CID);
+    let vm_listener_path = format!("worker-{}.sock_1234", cli.vmconfig.vsock_cid);
     let _ = std::fs::remove_file(&vm_listener_path);
     let vm_listener = UnixListener::bind(vm_listener_path).expect("bind to the UNIX listener");
-    let force_exit = cmd_arguments.is_present("force exit");
+    let force_exit = cli.force_exit;
     if let Err(e) = vm.launch(
         vm_listener.try_clone().unwrap(),
-        CID,
+        cli.vmconfig.vsock_cid,
         force_exit,
         vm_app_config,
         Some(odirect),
@@ -293,26 +99,30 @@ fn main() {
     let num_req = requests.len();
     let mut num_rsp = 0;
 
-    let mypriv = cmd_arguments
-        .value_of("login")
+    let mypriv = cli
+        .login
+        .as_ref()
         .map_or(buckle::Component::dc_true(), |p| {
             Buckle::parse(&("T,".to_string() + p)).unwrap().integrity
         });
-    let startlbl = cmd_arguments
-        .value_of("secrecy")
-        .map_or(Buckle::public(), |s| {
-            Buckle::parse(&(s.to_string() + ",T")).unwrap()
-        });
+    let startlbl = cli
+        .start_label
+        .as_ref()
+        .map_or(Buckle::public(), |s| Buckle::parse(s).unwrap());
 
-    let fs: FS<Box<dyn BackingStore>> =
-        match cmd_arguments.value_of("tikv proxies").map(|ts| ts.split_whitespace().into_iter().collect()) {
-            None => FS::new(Box::new(&*DBENV)),
-            Some(tikv_pds) => FS::new({
-                            let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-                            let client = rt.block_on(async { tikv_client::RawClient::new(tikv_pds, None).await.unwrap() });
-                            Box::new(TikvClient::new(client, Arc::new(rt)))
-                        }),
-        };
+    let fs: FS<Box<dyn BackingStore>> = if let Some(tikv_pds) = cli.store.tikv {
+        FS::new({
+            let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+            let client =
+                rt.block_on(async { tikv_client::RawClient::new(tikv_pds, None).await.unwrap() });
+            Box::new(TikvClient::new(client, Arc::new(rt)))
+        })
+    } else if let Some(path) = cli.store.lmdb.as_ref() {
+        let dbenv = std::boxed::Box::leak(Box::new(snapfaas::fs::lmdb::get_dbenv(path)));
+        FS::new(Box::new(&*dbenv))
+    } else {
+        panic!("We shouldn't reach here.");
+    };
 
     let mut env = SyscallGlobalEnv {
         sched_conn: None,
@@ -321,7 +131,7 @@ fn main() {
     };
 
     // Synchronously send the request to vm and wait for a response
-    let dump_working_set = true && cmd_arguments.is_present("dump working set");
+    let dump_working_set = true && cli.vmconfig.dump_ws;
     for req in requests {
         let t1 = Instant::now();
         debug!("request: {:?}", req);

--- a/snapfaas/src/cli.rs
+++ b/snapfaas/src/cli.rs
@@ -1,0 +1,79 @@
+//! Definitions of common CLI arguments
+
+use clap::Args;
+
+#[derive(Args, Debug)]
+#[group(multiple = true, required = true)]
+pub struct VmConfig {
+    /// MicroVM ID
+    #[arg(long, default_value_t = 0)]
+    pub id: u64,
+    /// Path of the kernel
+    #[arg(short, long, value_name = "PATH")]
+    pub kernel: String,
+    /// Kernel boot args (e.g. quiet,console=ttyS0)
+    #[arg(long, value_name = "FLAG|KEY=VALUE,...")]
+    pub kernel_args: Option<String>,
+    /// Path of the root file-system
+    #[arg(short, long, value_name = "PATH")]
+    pub rootfs: String,
+    /// Path of the app file-system, mounted at "/srv" in the microVM
+    #[arg(long, value_name = "PATH")]
+    pub appfs: Option<String>,
+    /// Memory size in MB of the microVM
+    #[arg(long, value_name = "MB", default_value_t = 128)]
+    pub memory: u32,
+    /// VCPU count of the microVM
+    #[arg(long, value_name = "COUNT", default_value_t = 1)]
+    pub vcpu: u32,
+    /// CID of the microVM's vsock
+    #[arg(long, value_name = "CID", default_value_t = 100)]
+    pub vsock_cid: u32,
+    /// MAC address of the microVM's network device
+    #[arg(long, value_name = "MAC", group = "network", requires = "tap")]
+    pub mac: Option<String>,
+    /// Name of the tap device that backs the microVM's network device
+    #[arg(long, value_name = "NAME", group = "network")]
+    pub tap: Option<String>,
+    /// Directory to load the snapshot from
+    #[arg(long, value_name = "PATH", group = "load_snapshot")]
+    pub load_dir: Option<String>,
+    /// If present, load the working set
+    #[arg(long, group = "load_snapshot")]
+    pub load_ws: bool,
+    /// If present, restore the base memory snapshot by copying
+    #[arg(long, group = "load_snapshot")]
+    pub copy_base_memory: bool,
+    /// If present, restore the diff memory snapshot by copying
+    #[arg(long, group = "load_snapshot")]
+    pub copy_diff_memory: bool,
+    /// Directory to create the snapshot in
+    #[arg(long, value_name = "PATH", group = "dump_snapshot")]
+    pub dump_dir: Option<String>,
+    /// If present, dump the working set
+    #[arg(long, group = "dump_snapshot")]
+    pub dump_ws: bool,
+    /// If present, open base memory snapshot with O_DIRECT
+    #[arg(long, group = "odirect", requires = "load_snapshot")]
+    pub odirect_base: bool,
+    /// If present, don't open diff memory snapshot with O_DIRECT
+    #[arg(long, group = "odirect", requires = "load_snapshot")]
+    pub no_odirect_diff: bool,
+    /// If present, don't open rootfs with O_DIRECT (required when using tmpfs)
+    #[arg(long, group = "odirect")]
+    pub no_odirect_root: bool,
+    /// If present, don't open appfs with O_DIRECT (required when using tmpfs)
+    #[arg(long, group = "odirect")]
+    pub no_odirect_app: bool,
+}
+
+#[derive(Args, Debug)]
+#[group(required = true)]
+pub struct Store {
+    /// Space delimited addresses of TiKV PDs
+    #[arg(long, value_name = "ADDR:PORT")]
+    pub tikv: Option<Vec<String>>,
+    /// Path of the LMDB directory
+    #[arg(long, value_name = "PATH")]
+    pub lmdb: Option<String>,
+}

--- a/snapfaas/src/cli.rs
+++ b/snapfaas/src/cli.rs
@@ -1,9 +1,8 @@
 //! Definitions of common CLI arguments
 
-use clap::Args;
+use clap::{Args, Parser};
 
-#[derive(Args, Debug)]
-#[group(multiple = true, required = true)]
+#[derive(Parser, Debug)]
 pub struct VmConfig {
     /// MicroVM ID
     #[arg(long, default_value_t = 0)]
@@ -39,19 +38,24 @@ pub struct VmConfig {
     #[arg(long, value_name = "PATH", group = "load_snapshot")]
     pub load_dir: Option<String>,
     /// If present, load the working set
-    #[arg(long, group = "load_snapshot")]
+    #[arg(long, group = "load_snapshot", requires = "load_dir")]
     pub load_ws: bool,
     /// If present, restore the base memory snapshot by copying
-    #[arg(long, group = "load_snapshot")]
+    #[arg(long, group = "load_snapshot", requires = "load_dir")]
     pub copy_base_memory: bool,
     /// If present, restore the diff memory snapshot by copying
-    #[arg(long, group = "load_snapshot")]
+    #[arg(long, group = "load_snapshot", requires = "load_dir")]
     pub copy_diff_memory: bool,
     /// Directory to create the snapshot in
-    #[arg(long, value_name = "PATH", group = "dump_snapshot")]
+    #[arg(
+        long,
+        value_name = "PATH",
+        group = "dump_snapshot",
+        conflicts_with = "load_snapshot"
+    )]
     pub dump_dir: Option<String>,
     /// If present, dump the working set
-    #[arg(long, group = "dump_snapshot")]
+    #[arg(long, group = "dump_snapshot", requires = "dump_dir")]
     pub dump_ws: bool,
     /// If present, open base memory snapshot with O_DIRECT
     #[arg(long, group = "odirect", requires = "load_snapshot")]
@@ -68,7 +72,7 @@ pub struct VmConfig {
 }
 
 #[derive(Args, Debug)]
-#[group(required = true)]
+#[group(required = true, multiple = false)]
 pub struct Store {
     /// Space delimited addresses of TiKV PDs
     #[arg(long, value_name = "ADDR:PORT")]

--- a/snapfaas/src/configs.rs
+++ b/snapfaas/src/configs.rs
@@ -112,9 +112,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FunctionConfig {
+    /// enable network, requires "tap"
+    #[serde(default)]
+    pub mac: Option<String>,
     /// enable network
     #[serde(default)]
-    pub network: bool,
+    pub tap: Option<String>,
     /// path to runtimefs
     pub runtimefs: String,
     /// path to appfs
@@ -156,7 +159,7 @@ pub struct FunctionConfig {
 
 impl From<super::fs::Function> for FunctionConfig {
     fn from(f: super::fs::Function) -> Self {
-        let mut default = Self::default(); 
+        let mut default = Self::default();
         default.memory = f.memory;
         default.runtimefs = f.runtime_image;
         default.appfs = Some(f.app_image);
@@ -168,7 +171,8 @@ impl From<super::fs::Function> for FunctionConfig {
 impl Default for FunctionConfig {
     fn default() -> Self {
         FunctionConfig {
-            network: false,
+            mac: None,
+            tap: None,
             kernel: String::new(),
             runtimefs: String::new(),
             appfs: None,

--- a/snapfaas/src/fs/lmdb.rs
+++ b/snapfaas/src/fs/lmdb.rs
@@ -1,23 +1,20 @@
 use std::time::Instant;
 
 use super::STAT;
-use lazy_static;
-use lmdb::{self, Transaction, WriteFlags, Cursor};
+use lmdb::{self, Cursor, Transaction, WriteFlags};
 
-lazy_static::lazy_static! {
-    pub static ref DBENV: lmdb::Environment = {
-        if !std::path::Path::new("storage").exists() {
-            let _ = std::fs::create_dir("storage").unwrap();
-        }
+pub fn get_dbenv(path: &str) -> lmdb::Environment {
+    let path = std::path::Path::new(path);
+    if !path.exists() {
+        let _ = std::fs::create_dir(path).unwrap();
+    }
 
-        lmdb::Environment::new()
-            .set_map_size(100 * 1024 * 1024 * 1024)
-            .set_max_readers(1024)
-            .open(std::path::Path::new("storage"))
-            .unwrap()
-    };
+    lmdb::Environment::new()
+        .set_map_size(100 * 1024 * 1024 * 1024)
+        .set_max_readers(1024)
+        .open(path)
+        .unwrap()
 }
-
 
 impl super::BackingStore for lmdb::Environment {
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {

--- a/snapfaas/src/lib.rs
+++ b/snapfaas/src/lib.rs
@@ -5,6 +5,7 @@ pub mod worker;
 // TODO what metrics do we want?
 //pub mod metrics;
 pub mod blobstore;
+pub mod cli;
 pub mod firecracker_wrapper;
 pub mod fs;
 pub mod sched;
@@ -14,7 +15,6 @@ pub mod vm;
 use log::error;
 use std::io::{BufRead, BufReader};
 
-//const LOCAL_FILE_URL_PREFIX: &str = "file://localhost";
 const MEM_FILE: &str = "/proc/meminfo"; // meminfo file on linux
 const KB_IN_MB: usize = 1024;
 
@@ -46,52 +46,6 @@ pub fn unlink_unix_sockets() {
         }
     }
 }
-
-///// check if a string is a url string
-///// TODO: maybe a more comprehensive check is needed but low priority
-//pub fn check_url(path: &str) -> bool {
-//    return path.starts_with("file://")
-//         | path.starts_with("http://")
-//         | path.starts_with("https://")
-//         | path.starts_with("ftp://");
-//}
-//
-//
-///// Check if a path is local filesystem path. If yes, append file://localhost/;
-///// If the path is already an URL, return itself.
-///// This function supports absolute path and relative path containing only "." and "..".
-///// An error is returned when the path does not exist.
-//pub fn convert_fs_path_to_url (path: &str) -> Result<String> {
-//    if check_url(path) {
-//        return Ok(path.to_string());
-//    }
-//    let mut url = String::from(LOCAL_FILE_URL_PREFIX);
-//    // unwrap is safe as the path is utf-8 valid
-//    let path = std::fs::canonicalize(path).map(|p| p.to_str().unwrap().to_string())?;
-//    url.push_str(path.as_str());
-//
-//    return Ok(url);
-//}
-//
-///// Open a file specified by a URL in the form of a string
-//pub fn open_url(url: &str) -> Result<std::fs::File> {
-//    if !check_url(url) {
-//        return Err(Error::new(ErrorKind::Other, "not Url"));
-//    }
-//
-//    match Url::parse(url) {
-//        Ok(url)=> {
-//            //println!("{:?}", url);
-//            //println!("{:?}", url.scheme());
-//            //println!("{:?}", url.host());
-//            //println!("{:?}", url.path());
-//            //println!("{:?}", url.username());
-//            return std::fs::File::open(url.path());
-//        }
-//        Err(_)=> return Err(Error::new(ErrorKind::Other, "Url parse failed")),
-//    }
-//
-//}
 
 pub fn get_machine_memory() -> usize {
     let memfile = std::fs::File::open(MEM_FILE).expect("Couldn't open /proc/meminfo");

--- a/snapfaas/src/vm.rs
+++ b/snapfaas/src/vm.rs
@@ -17,7 +17,7 @@ use crate::syscall_server::{SyscallChannel, SyscallChannelError};
 use crate::syscalls;
 use crate::syscalls::syscall::Syscall as SC;
 
-const MACPREFIX: &str = "AA:BB:CC:DD";
+//const MACPREFIX: &str = "AA:BB:CC:DD";
 
 #[derive(Debug)]
 pub enum Error {
@@ -92,8 +92,7 @@ impl Vm {
             return Ok(());
         }
         let mem_str = function_config.memory.to_string();
-        // FIXME num_vcpu should scale with memory size.
-        let vcpu_str = 1usize.to_string();
+        let vcpu_str = function_config.vcpus.to_string();
         let cid_str = cid.to_string();
         let id_str = self.id.to_string();
         let mut args = vec![
@@ -137,16 +136,16 @@ impl Vm {
         }
 
         // network config should be of the format <TAP-Name>/<MAC Address>
-        let tap_name = format!("tap{}", cid - 100);
-        let mac_addr = format!(
-            "{}:{:02X}:{:02X}",
-            MACPREFIX,
-            ((cid - 100) & 0xff00) >> 8,
-            (cid - 100) & 0xff
-        );
-        if function_config.network {
-            args.extend_from_slice(&["--tap_name", &tap_name]);
-            args.extend_from_slice(&["--mac", &mac_addr]);
+        //let tap_name = format!("tap{}", cid - 100);
+        //let mac_addr = format!(
+        //    "{}:{:02X}:{:02X}",
+        //    MACPREFIX,
+        //    ((cid - 100) & 0xff00) >> 8,
+        //    (cid - 100) & 0xff
+        //);
+        if function_config.mac.is_some() {
+            args.extend_from_slice(&["--tap_name", function_config.tap.as_ref().unwrap()]);
+            args.extend_from_slice(&["--mac", function_config.mac.as_ref().unwrap()]);
         }
 
         // odirect


### PR DESCRIPTION
The PR contains a reimplementation of the CLI commands using the new "derive" syntax.

The new syntax allows us to centralize a set of common arguments (snapfaas/src/cli.rs) and easily declares argument relationships. For example, one should specify exactly one of the tikv store and lmdb store (as this is required, the static DBENV is no longer needed and removed).