### PR TITLE
Fix CLI arguments

### DIFF
--- a/snapfaas/bins/firerunner/main.rs
+++ b/snapfaas/bins/firerunner/main.rs
@@ -40,23 +40,23 @@ fn main() {
 
     // optional arguments:
     let appfs = args.appfs.map(PathBuf::from);
-    let dump_dir = args.dump_dir.map(PathBuf::from);
-    let load_dir = args.load_dir.map_or(Vec::new(), |x| {
+    let dump_dir = args.dump.dump_dir.map(PathBuf::from);
+    let load_dir = args.load.load_dir.map_or(Vec::new(), |x| {
         x.split(',')
             .collect::<Vec<&str>>()
             .iter()
             .map(PathBuf::from)
             .collect()
     });
-    let copy_base = args.copy_base_memory;
-    let copy_diff = args.copy_diff_memory;
-    let odirect_base = args.odirect_base;
-    let odirect_diff = !args.no_odirect_diff;
+    let copy_base = args.load.copy_base_memory;
+    let copy_diff = args.load.copy_diff_memory;
+    let odirect_base = args.load.odirect_base;
+    let odirect_diff = !args.load.no_odirect_diff;
     let odirect_rootfs = !args.no_odirect_root;
     let odirect_appfs = !args.no_odirect_app;
-    let load_ws = args.load_ws;
-    let mac = args.mac;
-    let tap_name = args.tap;
+    let load_ws = args.load.load_ws;
+    let mac = args.network.mac;
+    let tap_name = args.network.tap;
     let cid = args.vsock_cid;
 
     // Make sure kernel, rootfs, appfs, load_dir, dump_dir exist
@@ -222,7 +222,7 @@ fn main() {
     }
 
     // listen for dump working set
-    if args.dump_ws {
+    if args.dump.dump_ws {
         let listener_port = format!("dump_ws-{}.sock", instance_id);
         let unix_sock_listener =
             UnixListener::bind(listener_port).expect("Failed to bind to unix listener");

--- a/snapfaas/src/cli.rs
+++ b/snapfaas/src/cli.rs
@@ -28,47 +28,63 @@ pub struct VmConfig {
     /// CID of the microVM's vsock
     #[arg(long, value_name = "CID", default_value_t = 100)]
     pub vsock_cid: u32,
-    /// MAC address of the microVM's network device
-    #[arg(long, value_name = "MAC", group = "network", requires = "tap")]
-    pub mac: Option<String>,
-    /// Name of the tap device that backs the microVM's network device
-    #[arg(long, value_name = "NAME", group = "network")]
-    pub tap: Option<String>,
-    /// Directory to load the snapshot from
-    #[arg(long, value_name = "PATH", group = "load_snapshot")]
-    pub load_dir: Option<String>,
-    /// If present, load the working set
-    #[arg(long, group = "load_snapshot", requires = "load_dir")]
-    pub load_ws: bool,
-    /// If present, restore the base memory snapshot by copying
-    #[arg(long, group = "load_snapshot", requires = "load_dir")]
-    pub copy_base_memory: bool,
-    /// If present, restore the diff memory snapshot by copying
-    #[arg(long, group = "load_snapshot", requires = "load_dir")]
-    pub copy_diff_memory: bool,
-    /// Directory to create the snapshot in
-    #[arg(
-        long,
-        value_name = "PATH",
-        group = "dump_snapshot",
-        conflicts_with = "load_snapshot"
-    )]
-    pub dump_dir: Option<String>,
-    /// If present, dump the working set
-    #[arg(long, group = "dump_snapshot", requires = "dump_dir")]
-    pub dump_ws: bool,
-    /// If present, open base memory snapshot with O_DIRECT
-    #[arg(long, group = "odirect", requires = "load_snapshot")]
-    pub odirect_base: bool,
-    /// If present, don't open diff memory snapshot with O_DIRECT
-    #[arg(long, group = "odirect", requires = "load_snapshot")]
-    pub no_odirect_diff: bool,
+    #[command(flatten)]
+    pub network: Network,
+    #[command(flatten)]
+    pub load: Load,
+    #[command(flatten)]
+    pub dump: Dump,
     /// If present, don't open rootfs with O_DIRECT (required when using tmpfs)
-    #[arg(long, group = "odirect")]
+    #[arg(long)]
     pub no_odirect_root: bool,
     /// If present, don't open appfs with O_DIRECT (required when using tmpfs)
-    #[arg(long, group = "odirect")]
+    #[arg(long)]
     pub no_odirect_app: bool,
+}
+
+#[derive(Args, Debug)]
+#[group(required = false, multiple = true)]
+pub struct Network {
+    /// MAC address of the microVM's network device
+    #[arg(long, value_name = "MAC", requires = "tap")]
+    pub mac: Option<String>,
+    /// Name of the tap device that backs the microVM's network device
+    #[arg(long, value_name = "NAME")]
+    pub tap: Option<String>,
+}
+
+#[derive(Args, Debug)]
+#[group(required = false, multiple = true)]
+pub struct Load {
+    /// Directory to load the snapshot from
+    #[arg(long, value_name = "PATH")]
+    pub load_dir: Option<String>,
+    /// If present, load the working set
+    #[arg(long, requires = "load_dir")]
+    pub load_ws: bool,
+    /// If present, restore the base memory snapshot by copying
+    #[arg(long, requires = "load_dir")]
+    pub copy_base_memory: bool,
+    /// If present, restore the diff memory snapshot by copying
+    #[arg(long, requires = "load_dir")]
+    pub copy_diff_memory: bool,
+    /// If present, open base memory snapshot with O_DIRECT
+    #[arg(long, requires = "load_dir")]
+    pub odirect_base: bool,
+    /// If present, don't open diff memory snapshot with O_DIRECT
+    #[arg(long, requires = "load_dir")]
+    pub no_odirect_diff: bool,
+}
+
+#[derive(Args, Debug)]
+#[group(required = false, multiple = true, conflicts_with = "Load")]
+pub struct Dump {
+    /// Directory to create the snapshot in
+    #[arg(long, value_name = "PATH")]
+    pub dump_dir: Option<String>,
+    /// If present, dump the working set
+    #[arg(long, requires = "dump_dir")]
+    pub dump_ws: bool,
 }
 
 #[derive(Args, Debug)]

--- a/snapfaas/src/vm.rs
+++ b/snapfaas/src/vm.rs
@@ -114,21 +114,21 @@ impl Vm {
             args.extend_from_slice(&["--appfs", f]);
         }
         if let Some(load_dir) = function_config.load_dir.as_ref() {
-            args.extend_from_slice(&["--load_from", load_dir]);
+            args.extend_from_slice(&["--load-from", load_dir]);
             if function_config.copy_base {
-                args.push("--copy_base");
+                args.push("--copy-base");
             }
             if function_config.copy_diff {
-                args.push("--copy_diff");
+                args.push("--copy-diff");
             }
             if function_config.load_ws {
-                args.push("--load_ws");
+                args.push("--load-ws");
             }
         }
         if let Some(dump_dir) = function_config.dump_dir.as_ref() {
-            args.extend_from_slice(&["--dump_to", dump_dir]);
+            args.extend_from_slice(&["--dump-to", dump_dir]);
             if function_config.dump_ws {
-                args.push("--dump_ws");
+                args.push("--dump-ws");
             }
         }
         if let Some(cmdline) = function_config.cmdline.as_ref() {
@@ -146,23 +146,23 @@ impl Vm {
         //    (cid - 100) & 0xff
         //);
         if function_config.mac.is_some() {
-            args.extend_from_slice(&["--tap_name", function_config.tap.as_ref().unwrap()]);
+            args.extend_from_slice(&["--tap-name", function_config.tap.as_ref().unwrap()]);
             args.extend_from_slice(&["--mac", function_config.mac.as_ref().unwrap()]);
         }
 
         // odirect
         if let Some(odirect) = odirect {
             if odirect.base {
-                args.push("--odirect_base");
+                args.push("--odirect-base");
             }
             if !odirect.diff {
-                args.push("--no_odirect_diff");
+                args.push("--no-odirect-diff");
             }
             if !odirect.rootfs {
-                args.push("--no_odirect_root");
+                args.push("--no-odirect-root");
             }
             if !odirect.appfs {
-                args.push("--no_odirect_app");
+                args.push("--no-odirect-app");
             }
         }
 


### PR DESCRIPTION
This patch fixes three problems:

1. CLI arguments should contain dashes instead of underscores
2. CLI argument groups `Load`, `Dump`, `Network` were wrongly specified
3. CLI odirect flags handling was wrong