### PR TITLE
Make webfront act as a passthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,6 +2532,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest",
+ "rouille",
  "serde",
  "serde_json",
  "serde_with",

--- a/frontends/webfront/src/init.rs
+++ b/frontends/webfront/src/init.rs
@@ -46,7 +46,15 @@ pub fn init<S: BackingStore>(
 fn prepare_payload(
     request: &Request,
     blobstore: Arc<Mutex<Blobstore>>,
-) -> Result<(Vec<u8>, HashMap<String, blobstore::Blob>, Option<buckle::Buckle>, HashMap<String, String>), Response> {
+) -> Result<
+    (
+        Vec<u8>,
+        HashMap<String, blobstore::Blob>,
+        Option<buckle::Buckle>,
+        HashMap<String, String>,
+    ),
+    Response,
+> {
     // Parse input into a 3-tuple. support two content types:
     // * multipart/form-data
     // * application/json (passthrough)
@@ -61,12 +69,16 @@ fn prepare_payload(
         .map_err(|_| {
             Response::json(&serde_json::json!({"error": "Unknown MIME"})).with_status_code(415)
         })?;
-        let headers: HashMap<String, String> = request.headers().filter_map(|(k,v)|
-            if k.eq_ignore_ascii_case("authorization") {
-                None
-            } else {
-                Some((k.to_ascii_lowercase(), v.to_string()))
-            }).collect();
+        let headers: HashMap<String, String> = request
+            .headers()
+            .filter_map(|(k, v)| {
+                if k.eq_ignore_ascii_case("authorization") {
+                    None
+                } else {
+                    Some((k.to_ascii_lowercase(), v.to_string()))
+                }
+            })
+            .collect();
         // get rid of the `boundary` param in multipart/form-data
         let essence_type = mime::Mime::from_str(content_type.essence_str()).unwrap();
         if essence_type == mime::MULTIPART_FORM_DATA {
@@ -74,11 +86,13 @@ fn prepare_payload(
                 blob: Vec<BufferedFile>, payload: String, label: Option<String>
             })
             .map_err(|e| {
-                Response::json(&serde_json::json!({"error": format!("{:?}", e)})).with_status_code(400)
+                Response::json(&serde_json::json!({"error": format!("{:?}", e)}))
+                    .with_status_code(400)
             })?;
             let label = if let Some(label) = &parsed_form.label {
                 Some(buckle::Buckle::parse(label).map_err(|e| {
-                    Response::json(&serde_json::json!({"error": e.to_string()})).with_status_code(400)
+                    Response::json(&serde_json::json!({"error": e.to_string()}))
+                        .with_status_code(400)
                 })?)
             } else {
                 None
@@ -86,7 +100,9 @@ fn prepare_payload(
             (parsed_form.blob, parsed_form.payload, label, headers)
         } else if essence_type == mime::APPLICATION_JSON {
             let mut payload = String::new();
-            let label = request.header("x-faasten-label").and_then(|b| Buckle::parse(b).ok());
+            let label = request
+                .header("x-faasten-label")
+                .and_then(|b| Buckle::parse(b).ok());
             let _ = request
                 .data()
                 .unwrap()
@@ -119,15 +135,10 @@ fn prepare_payload(
         newblob.write_all(f.data.as_ref()).map_err(|e| {
             Response::json(&serde_json::json!({"error": e.to_string()})).with_status_code(500)
         })?;
-        let blob = blobstore
-            .lock()
-            .unwrap()
-            .save(newblob)
-            .map_err(|e| {
-                Response::json(&serde_json::json!({"error": e.to_string()})).with_status_code(500)
-            })?;
+        let blob = blobstore.lock().unwrap().save(newblob).map_err(|e| {
+            Response::json(&serde_json::json!({"error": e.to_string()})).with_status_code(500)
+        })?;
         blobs.insert(f.filename.clone().unwrap_or(format!("blob{}", i)), blob);
-
     }
     Ok((payload.to_string().into(), blobs, label, headers))
 }
@@ -142,9 +153,11 @@ fn prepare_labeled_invoke<S: BackingStore>(
     let path = fs::path::Path::parse(&gate_path).map_err(|_| {
         Response::json(&serde_json::json!({"error": "Invalid path."})).with_status_code(400)
     })?;
-    let (f, gate_privilege) = fs::utils::resolve_gate_with_clearance_check(fs, path).map_err(|e| {
-        Response::json(&serde_json::json!({ "error": format!("{:?}", e) })).with_status_code(400)
-    })?;
+    let (f, gate_privilege) =
+        fs::utils::resolve_gate_with_clearance_check(fs, path).map_err(|e| {
+            Response::json(&serde_json::json!({ "error": format!("{:?}", e) }))
+                .with_status_code(400)
+        })?;
     let gate_privilege = Some(gate_privilege.into());
     let label = fs::utils::get_current_label();
     let label = label.into();
@@ -184,52 +197,32 @@ fn wait_for_completion(
     })?;
 
     use prost::Message;
-    use snapfaas::sched::message::{ReturnCode, TaskReturn};
-    let ret = match TaskReturn::decode(bs.as_slice()) {
-        Ok(TaskReturn { code, payload, label }) => {
-            if !Into::<Buckle>::into(label.clone().unwrap()).can_flow_to_with_privilege(&fs::utils::get_current_label(), &fs::utils::get_privilege()) {
+    use snapfaas::sched::message::TaskReturn;
+    match TaskReturn::decode(bs.as_slice()) {
+        Ok(tr) => {
+            if !Into::<Buckle>::into(tr.label.clone().unwrap()).can_flow_to_with_privilege(
+                &fs::utils::get_current_label(),
+                &fs::utils::get_privilege(),
+            ) {
                 Err(Response::json(&serde_json::json!({
                     "error": "unauthorized to read response",
-                    "label": format!("{:?}", Into::<Buckle>::into(label.unwrap())),
+                    "label": format!("{:?}", Into::<Buckle>::into(tr.label.unwrap())),
                     "current_label": format!("{:?}", fs::utils::get_current_label()),
                     "privilege": format!("{:?}", fs::utils::get_privilege())
                 }))
                 .with_status_code(401))
             } else {
-                match ReturnCode::from_i32(code) {
-                    Some(ReturnCode::QueueFull) => Err(Response::json(&serde_json::json!({
-                        "error": "queue full"
-                    }))
-                    .with_status_code(500)),
-                    Some(ReturnCode::LaunchFailed) => Err(Response::json(&serde_json::json!({
-                        "error": "failed to launch the VM"
-                    }))
-                    .with_status_code(500)),
-                    Some(ReturnCode::GateNotExist) => Err(Response::json(&serde_json::json!({
-                        "error": "gate does not exist"
-                    }))
-                    .with_status_code(500)),
-                    Some(ReturnCode::ResourceExhausted) => Err(Response::json(&serde_json::json!({
-                        "error": "resource exhausted"
-                    }))
-                    .with_status_code(500)),
-                    Some(ReturnCode::ProcessRequestFailed) => Err(Response::json(&serde_json::json!({
-                        "error": "failed to process request"
-                    }))
-                    .with_status_code(500)),
-                    Some(ReturnCode::Success) => Ok(payload.unwrap()),
-                    None => Err(Response::json(&serde_json::json!({
-                        "error": "unknown return code"
-                    }))
-                    .with_status_code(500)),
+                let resp: Response = tr.into();
+                if resp.is_success() {
+                    Ok(resp)
+                } else {
+                    Err(resp)
                 }
             }
-        },
+        }
         Err(_) => Err(Response::json(&serde_json::json!({
             "error": "failed to decode return from Faasten core"
         }))
         .with_status_code(500)),
-    }?;
-
-    Ok(Response::from_data("application/octet-stream", ret))
+    }
 }

--- a/functions/build.sh
+++ b/functions/build.sh
@@ -2,10 +2,9 @@
 
 set -e
 
-
-rm -f `basename $1`.img
+rm -f output/$(basename $1).img
 if [ -f $d/Makefile ]; then
-  ./docker_build.sh "$1" output/$(basename "$1").img
+	./docker_build.sh "$1" output/$(basename "$1").img
 else
-  gensquashfs --pack-dir "$1" output/$(basename "$1").img
+	gensquashfs --pack-dir "$1" output/$(basename "$1").img
 fi

--- a/functions/fsutil/workload.py
+++ b/functions/fsutil/workload.py
@@ -3,6 +3,8 @@ import json
 import base64
 from contextlib import ExitStack
 
+from syscalls import ResponseDict
+
 def handle(syscall, payload=b'', blobs={}, **kwargs):
     request = json.loads(payload)
     args = request['args']
@@ -221,7 +223,7 @@ def handle(syscall, payload=b'', blobs={}, **kwargs):
         case _:
             ret['success'] = False
             ret['error'] = '[fsutil] unknown op'
-    return ret
+    return ResponseDict(ret)
 
 #def trigger(triggers, syscall, op, path):
 #    ret = {'success': [], 'failure': []}

--- a/functions/hello/workload.py
+++ b/functions/hello/workload.py
@@ -1,2 +1,4 @@
-def handle(obj, syscall):
-    return {}
+from syscalls import ResponseDict
+
+def handle(syscall, payload=b'', blobs={}, **kwargs):
+    return ResponseDict({})

--- a/functions/princeton-cas/login-bytes/workload.py
+++ b/functions/princeton-cas/login-bytes/workload.py
@@ -1,0 +1,9 @@
+from syscalls import ResponseRaw
+BASE_URL = "sns40.cs.princeton.edu"
+def handle(syscall, payload=b'', blobs={}, **kwargs):
+    redirect_url = "https://fed.princeton.edu/cas"
+    # TODO replace the URL to the path to the auth gate
+    callback_url = f"{BASE_URL}/authenticate/cas"
+    body = f"{redirect_url}/login?service={callback_url}"
+    status_code = 302
+    return ResponseRaw(body.encode('utf-8'), status_code)

--- a/functions/princeton-cas/login/workload.py
+++ b/functions/princeton-cas/login/workload.py
@@ -1,0 +1,9 @@
+from syscalls import ResponseStr
+BASE_URL = "sns40.cs.princeton.edu"
+def handle(syscall, payload=b'', blobs={}, **kwargs):
+    redirect_url = "https://fed.princeton.edu/cas"
+    # TODO replace the URL to the path to the auth gate
+    callback_url = f"{BASE_URL}/authenticate/cas"
+    body = f"{redirect_url}/login?service={callback_url}"
+    status_code = 302
+    return ResponseStr(body, status_code)

--- a/rootfs/runtimes/python3/workload.py
+++ b/rootfs/runtimes/python3/workload.py
@@ -5,8 +5,7 @@ import json
 import socket
 import sys
 import traceback
-import syscalls
-from syscalls import Syscall
+from syscalls import Syscall, Response, ResponseDict
 
 # vsock to communicate with the host
 VSOCKPORT = 1234
@@ -21,12 +20,7 @@ while True:
     try:
         request = sc.request()
         response = app.handle(sc, payload=request.payload, blobs=request.blobs, headers=request.headers)
-        if isinstance(response, dict):
-            response = json.dumps(response)
-
-        if isinstance(response, str):
-            response = response.encode('utf-8')
-
+        assert(isinstance(response, Response))
         sc.respond(response)
     except:
         ty, val, tb = sys.exc_info()
@@ -37,4 +31,4 @@ while True:
                 'traceback': traceback.format_tb(tb),
             },
         }
-        sc.respond(json.dumps(response).encode('utf-8'))
+        sc.respond(ResponseDict(response))

--- a/snapfaas/Cargo.toml
+++ b/snapfaas/Cargo.toml
@@ -87,6 +87,7 @@ tikv-client = "0.2.0"
 openssl = "*"
 jwt = { version = "0.15.0", features = [ "openssl" ]}
 strfmt = "*"
+rouille = "3.6.2"
 
 
 [build-dependencies]

--- a/snapfaas/src/sched/message.rs
+++ b/snapfaas/src/sched/message.rs
@@ -1,10 +1,53 @@
 include!(concat!(env!("OUT_DIR"), "/snapfaas.sched.messages.rs"));
 
 use prost::Message;
+use rouille;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 
 use super::Error;
+
+// respond 500 if fail to start the execution of the requested gate; otherwise, act as a passthrough, i.e., respond whatever the execution responds.
+impl From<TaskReturn> for rouille::Response {
+    fn from(tr: TaskReturn) -> rouille::Response {
+        use rouille::Response;
+        let mut resp = match ReturnCode::from_i32(tr.code) {
+            Some(ReturnCode::QueueFull) => Response::json(&serde_json::json!({
+                "error": "queue full"
+            }))
+            .with_status_code(500),
+            Some(ReturnCode::LaunchFailed) => Response::json(&serde_json::json!({
+                "error": "failed to launch the VM"
+            }))
+            .with_status_code(500),
+            Some(ReturnCode::GateNotExist) => Response::json(&serde_json::json!({
+                "error": "gate does not exist"
+            }))
+            .with_status_code(500),
+            Some(ReturnCode::ResourceExhausted) => Response::json(&serde_json::json!({
+                "error": "resource exhausted"
+            }))
+            .with_status_code(500),
+            Some(ReturnCode::ProcessRequestFailed) => Response::json(&serde_json::json!({
+                "error": "failed to process request"
+            }))
+            .with_status_code(500),
+            Some(ReturnCode::Success) => Response::from_data(
+                "application/octet-stream",
+                tr.payload.as_ref().unwrap().body(),
+            ),
+            None => Response::json(&serde_json::json!({
+                "error": "unknown return code"
+            }))
+            .with_status_code(500),
+        };
+        // act as a passthrough
+        if resp.is_success() {
+            resp = resp.with_status_code(tr.payload.unwrap().status_code as u16);
+        }
+        resp
+    }
+}
 
 fn _read_u8(stream: &mut TcpStream, allow_empty: bool) -> Result<Vec<u8>, Error> {
     let mut lenbuf = [0; 8];

--- a/snapfaas/src/sched/messages.proto
+++ b/snapfaas/src/sched/messages.proto
@@ -104,6 +104,6 @@ enum ReturnCode {
 
 message TaskReturn {
     ReturnCode code = 1;
-    optional bytes payload = 2;
+    syscalls.Response payload = 2;
     syscalls.Buckle label = 3;
 }

--- a/snapfaas/src/syscalls.proto
+++ b/snapfaas/src/syscalls.proto
@@ -46,7 +46,8 @@ message Request {
 }
 
 message Response {
-  bytes payload = 1;
+  optional bytes body = 1;
+  uint32 statusCode = 2;
 }
 
 message DentResult {


### PR DESCRIPTION
This patch includes three commits:

1. adding two functions princeton-cas/login&login-bytes for testing and bootstrapping moving authentication into functions
2. the second's main change is in snapfaas/src/sched/message.rs, converting TaskReturn to HTTP response
3. add library support for new syscalls:Response and update fsutil and hello