### PR TITLE
Add JWT function

### DIFF
--- a/frontends/webfront/src/init.rs
+++ b/frontends/webfront/src/init.rs
@@ -170,6 +170,7 @@ fn prepare_labeled_invoke<S: BackingStore>(
         headers,
         blobs,
         sync: true,
+        invoker: Some(fs::utils::get_privilege().into()),
     })
 }
 

--- a/functions/Dockerfile-python
+++ b/functions/Dockerfile-python
@@ -1,0 +1,5 @@
+FROM docker.io/library/alpine:3.16
+
+RUN apk add bash python3 python3-dev py3-pip
+
+ENV PYTHON python3.10

--- a/functions/README.md
+++ b/functions/README.md
@@ -8,6 +8,21 @@
 # The output is at ./output/*.img
 ./build.sh ./path/to/function/root
 ```
+# System Administration Functions
+* fsutil
+  * This function is installed during the system bootstrapping as a gate at "home:<T,faasten>:fsutil"
+    * The gate grants no privilege and allows anyone to invoke
+* jwt
+  * This function is installed during the system bootstrapping as a blob at "home:<faasten,faasten>:jwt"
+  * This function is installed for each identity provider (idp) as a gate at "home:<{idp}|faasten,faasten>:jwt"
+    * The gate grants "faasten" privilege so that an instance can read Faasten's private key
+    * The gate allows "{idp}" to invoke, which implies an instance will run with the privilege "faasten&{idp}"
+  * This function takes in a dict with "sub" key (standing for subject), generates a JWT for "sub", and registers for the authenticated user a private fsutil gate that redirects to the public fsutil gate mentioned above
+    * The private gate will be at "home:<{idp}/{sub},{idp}/{sub}>:fsutil"
 # TODO
-* support for installing native library
-* support for languages other than Python
+- [] support for installing native library
+- [] support for languages other than Python
+- [] administration
+  - [] install jwt during the system bootstrapping
+  - [] admin tool for install a new idp
+  - [] jwt registers fsutil

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,13 @@
+# Build Function Images
+* pre-req: docker and gensquashfs (included in squashfs-tools-ng on Ubuntu)
+* run:
+```sh
+# The script detects if there is a requirements.txt file.
+# If the file exists, the script runs ./docker_install.sh
+# to install the packages (e.g., jwt).
+# The output is at ./output/*.img
+./build.sh ./path/to/function/root
+```
+# TODO
+* support for installing native library
+* support for languages other than Python

--- a/functions/build.sh
+++ b/functions/build.sh
@@ -3,8 +3,10 @@
 set -e
 
 rm -f output/$(basename $1).img
-if [ -f $d/Makefile ]; then
-	./docker_build.sh "$1" output/$(basename "$1").img
-else
-	gensquashfs --pack-dir "$1" output/$(basename "$1").img
+if [ -f $1/requirements.txt ]; then
+	./docker_install.sh $(realpath $1)
+fi
+gensquashfs --pack-dir "$1" output/$(basename "$1").img
+if [ -f $1/requirements.txt ]; then
+	./docker_clean.sh $(realpath $1)
 fi

--- a/functions/docker_clean.sh
+++ b/functions/docker_clean.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker run --rm -v $1:/workdir -w /workdir faasten:pythonfunc rm -r package

--- a/functions/docker_install.sh
+++ b/functions/docker_install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+docker build -q -t faasten:pythonfunc -f Dockerfile-python .
+mkdir -p $1/package
+echo $1
+docker run --rm -v $1:/workdir -w /workdir faasten:pythonfunc pip3 install -r requirements.txt --target package

--- a/functions/jwt/requirements.txt
+++ b/functions/jwt/requirements.txt
@@ -1,0 +1,2 @@
+cryptography
+pyjwt

--- a/functions/jwt/workload.py
+++ b/functions/jwt/workload.py
@@ -6,20 +6,20 @@ from cryptography.hazmat.primitives import serialization
 import jwt
 import datetime
 
-PEM_FILE=['home', 'faasten,faasten', 'signkey']
-def handle(syscall, payload=b'', blobs={}, env={}, **kwargs):
+PEM_FILE=['home', 'faasten,faasten', 'private_key']
+def handle(syscall, payload=b'', blobs={}, invoker=[], **kwargs):
     request = json.loads(payload)
     sub = request['sub']
-    idp = 'princeton.edu' # TODO read this from env
+    # the invoker should be of length 1 and the tokens list should also be of length 1
+    idp = invoker[0].tokens[0]
     # read private key PEM file
-    with syscall.root().open_at(PEM_FILE) as entry:
-        with entry.get() as f:
-            data = f.read()
-            private_key = serialization.load_pem_private_key(
-                data,
-                password=None,  # replace with your password if the private key is encrypted
-                backend=default_backend()
-            )
+    with syscall.root().open_at(PEM_FILE) as f:
+        data = f.read()
+        private_key = serialization.load_pem_private_key(
+            data,
+            password=None,  # replace with your password if the private key is encrypted
+            backend=default_backend()
+        )
     claims = {
         "sub": f"{idp}/{sub}",          # subject (typically a user id)
         "iat": datetime.datetime.utcnow(),             # issued at

--- a/functions/jwt/workload.py
+++ b/functions/jwt/workload.py
@@ -1,0 +1,29 @@
+from syscalls import ResponseStr
+import json
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+import jwt
+import datetime
+
+PEM_FILE=['home', 'faasten,faasten', 'signkey']
+def handle(syscall, payload=b'', blobs={}, env={}, **kwargs):
+    request = json.loads(payload)
+    sub = request['sub']
+    idp = 'princeton.edu' # TODO read this from env
+    # read private key PEM file
+    with syscall.root().open_at(PEM_FILE) as entry:
+        with entry.get() as f:
+            data = f.read()
+            private_key = serialization.load_pem_private_key(
+                data,
+                password=None,  # replace with your password if the private key is encrypted
+                backend=default_backend()
+            )
+    claims = {
+        "sub": f"{idp}/{sub}",          # subject (typically a user id)
+        "iat": datetime.datetime.utcnow(),             # issued at
+        "exp": datetime.datetime.utcnow() + datetime.timedelta(days=1),  # expiration time
+    }
+    encoded_jwt = jwt.encode(claims, private_key, algorithm='ES256')
+    return ResponseStr(encoded_jwt)

--- a/functions/jwt/workload.py
+++ b/functions/jwt/workload.py
@@ -26,4 +26,12 @@ def handle(syscall, payload=b'', blobs={}, invoker=[], **kwargs):
         "exp": datetime.datetime.utcnow() + datetime.timedelta(days=1),  # expiration time
     }
     encoded_jwt = jwt.encode(claims, private_key, algorithm='ES256')
+
+    # TODO: declassify to remove "faasten" in secrecy
+    # syscall.declassify(f"{idp}")
+
+    # TODO:register fsutil for first timers
+    # i.e. copy the public fsutil gate over to ["home", f"{idp}/{sub},{idp}/{sub}", "fsutil"]
+    # Note that this gate should run with the privilege {idp}&faasten
+
     return ResponseStr(encoded_jwt)

--- a/rootfs/runtimes/python3/workload.py
+++ b/rootfs/runtimes/python3/workload.py
@@ -19,7 +19,7 @@ sc = Syscall(sock)
 while True:
     try:
         request = sc.request()
-        response = app.handle(sc, payload=request.payload, blobs=request.blobs, headers=request.headers)
+        response = app.handle(sc, payload=request.payload, blobs=request.blobs, headers=request.headers, invoker=request.invoker)
         assert(isinstance(response, Response))
         sc.respond(response)
     except:

--- a/snapfaas/bins/admin_fstools/main.rs
+++ b/snapfaas/bins/admin_fstools/main.rs
@@ -135,6 +135,10 @@ pub fn main() -> std::io::Result<()> {
             std::sync::Arc::new(rt),
         )))
     } else if let Some(lmdb) = cli.store.lmdb.as_ref() {
+        if !std::path::Path::new(lmdb).exists() {
+            eprintln!("LMDB path does not exist: {}", lmdb);
+            std::process::exit(1);
+        }
         let dbenv = std::boxed::Box::leak(Box::new(snapfaas::fs::lmdb::get_dbenv(lmdb)));
         FS::new(Box::new(&*dbenv))
     } else {

--- a/snapfaas/bins/singlevm/main.rs
+++ b/snapfaas/bins/singlevm/main.rs
@@ -137,7 +137,13 @@ fn main() {
         debug!("request: {:?}", req);
         let processor =
             syscall_server::SyscallProcessor::new(&mut env, startlbl.clone(), mypriv.clone());
-        match processor.run(req.into(), Default::default(), Default::default(), &mut vm) {
+        match processor.run(
+            req.into(),
+            Default::default(),
+            Default::default(),
+            mypriv.clone(),
+            &mut vm,
+        ) {
             Ok(rsp) => {
                 let t2 = Instant::now();
                 eprintln!(

--- a/snapfaas/src/sched/messages.proto
+++ b/snapfaas/src/sched/messages.proto
@@ -36,6 +36,7 @@ message LabeledInvoke {
     map <string, string> blobs            = 5;
     map <string, string> headers          = 6;
     bool                 sync             = 7;
+    syscalls.Component   invoker          = 8;
 }
 
 message UpdateResource {

--- a/snapfaas/src/sched/messages.proto
+++ b/snapfaas/src/sched/messages.proto
@@ -21,13 +21,6 @@ message Function {
   string kernel = 4;
 }
 
-message UnlabeledInvoke {
-    Function             function = 1;
-    bytes                payload  = 2;
-    map <string, string> blobs    = 3;
-    map <string, string> headers  = 4;
-}
-
 message LabeledInvoke {
     Function             function         = 1;
     syscalls.Buckle      label            = 2;
@@ -53,11 +46,6 @@ message ProcessTask {
     LabeledInvoke labeledInvoke = 2;
 }
 
-message ProcessTaskInsecure {
-    string taskId = 1;
-    UnlabeledInvoke unlabeledInvoke = 2;
-}
-
 message Terminate {}
 message Fail {}
 message Ping {}
@@ -76,7 +64,6 @@ message Request {
         // Debug
         TerminateAll   terminateAll   = 6;
         Ping           ping           = 7;
-        UnlabeledInvoke unlabeledInvoke = 8;
     }
 }
 
@@ -89,8 +76,6 @@ message Response {
         Fail        fail        = 3;
         TaskReturn  success     = 4;
         Pong        pong        = 5;
-        // Worker
-        ProcessTaskInsecure processTaskInsecure = 6;
     }
 }
 

--- a/snapfaas/src/sched/rpc.rs
+++ b/snapfaas/src/sched/rpc.rs
@@ -65,29 +65,6 @@ pub fn labeled_invoke(
     Ok(())
 }
 
-/// This method is for workers to invoke a function
-pub fn unlabeled_invoke(
-    stream: &mut TcpStream,
-    unlabeled_invoke: message::UnlabeledInvoke,
-) -> Result<(), Error> {
-    let req = Request {
-        kind: Some(ReqKind::UnlabeledInvoke(unlabeled_invoke)),
-    };
-    message::write(stream, &req)?;
-    //let _ = message::read_response(stream)?;
-    Ok(())
-}
-
-///// This method is to terminate all workers (for debug)
-//pub fn terminate_all(stream: &mut TcpStream) -> Result<(), Error> {
-//    let req = Request {
-//        kind: Some(ReqKind::TerminateAll(message::TerminateAll {})),
-//    };
-//    message::write(stream, &req)?;
-//    //let _ = message::read_response(stream)?;
-//    Ok(())
-//}
-
 /// This method is for local resource managers to update it's
 /// resource status, such as number of cached VMs per function
 pub fn update_resource(stream: &mut TcpStream, info: ResourceInfo) -> Result<(), Error> {

--- a/snapfaas/src/sched/rpc_server.rs
+++ b/snapfaas/src/sched/rpc_server.rs
@@ -117,32 +117,6 @@ impl RpcServer {
                         }
                     }
                 }
-                Some(Kind::UnlabeledInvoke(r)) => {
-                    debug!("RPC UNLABELED INVOKE received {:?}", r);
-                    let uuid = uuid::Uuid::new_v4();
-                    match queue_tx.try_send(Task::InvokeInsecure(uuid, r)) {
-                        Err(crossbeam::channel::TrySendError::Full(_)) => {
-                            warn!("Dropping Invocation from {:?}", stream.peer_addr());
-                            let ret = message::TaskReturn {
-                                code: message::ReturnCode::QueueFull as i32,
-                                payload: None,
-                                label: Some(fs::utils::get_current_label().into()),
-                            };
-                            let _ = message::write(&mut stream, &ret);
-                        }
-                        Err(crossbeam::channel::TrySendError::Disconnected(_)) => {
-                            panic!("Broken request queue")
-                        }
-                        Ok(()) => (),
-                    }
-                }
-                //Some(Kind::TerminateAll(_)) => {
-                //    debug!("RPC TERMINATEALL received");
-                //    let _ = manager.lock().unwrap().remove_all();
-                //    let res = Response { kind: None };
-                //    let _ = message::write(&mut stream, &res);
-                //    break;
-                //}
                 Some(Kind::UpdateResource(r)) => {
                     debug!("RPC UPDATE received");
                     let manager = &mut manager.lock().unwrap();

--- a/snapfaas/src/syscalls.proto
+++ b/snapfaas/src/syscalls.proto
@@ -43,6 +43,8 @@ message Request {
   bytes payload = 1;
   map <string, uint64> blobs = 2;
   map <string, string> headers = 3;
+  // list of principals in the invoker's privilege
+  repeated TokenList invoker = 4;
 }
 
 message Response {


### PR DESCRIPTION
A JWT function that reads the private key PEM and generates a JWT.

This patch also updated admin_fstools to generate public/private key pairs in the PEM format to Faasten file. This is part of system administration and can also help testing process. The JWT function is only tested using singlevm.
