### PR TITLE
Fix outdated Python library calls and add a newer VM image

### DIFF
--- a/bootstrap-config.yml
+++ b/bootstrap-config.yml
@@ -1,4 +1,4 @@
-kernel: resources/images/vmlinux-4.20.0
+kernel: resources/images/vmlinux-5.10.210
 python: rootfs/python3.img
 fsutil: functions/output/fsutil.img
 other_runtimes: []

--- a/rootfs/runtimes/python3/syscalls.py
+++ b/rootfs/runtimes/python3/syscalls.py
@@ -691,13 +691,13 @@ class Syscall():
         Yield:
             An instance of class NewBlob
         """
-        req = syscalls_pb2.Syscall(createBlob=syscalls_pb2.BlobCreate(size=size))
+        req = syscalls_pb2.Syscall(blobCreate=syscalls_pb2.BlobCreate(size=size))
         self._send(req)
         response = self._recv(syscalls_pb2.BlobResponse())
         if response.success:
             fd = response.fd
             yield NewBlob(fd, self)
-            syscalls_pb2.Syscall(closeBlob=syscalls_pb2.BlobClose(fd=fd))
+            syscalls_pb2.Syscall(blobClose=syscalls_pb2.BlobClose(fd=fd))
             self._send(req)
             response = self._recv(syscalls_pb2.BlobResponse())
         else:
@@ -739,13 +739,13 @@ class NewBlob():
         self.syscall = syscall
 
     def write(self, data):
-        req = syscalls_pb2.Syscall(writeBlob=syscalls_pb2.BlobWrite(fd=self.fd, data=data))
+        req = syscalls_pb2.Syscall(blobWrite=syscalls_pb2.BlobWrite(fd=self.fd, data=data))
         self.syscall._send(req)
         response = self.syscall._recv(syscalls_pb2.BlobResponse())
         return response.success
 
     def finalize(self, data):
-        req = syscalls_pb2.Syscall(finalizeBlob=syscalls_pb2.BlobFinalize(fd=self.fd, data=data))
+        req = syscalls_pb2.Syscall(blobFinalize=syscalls_pb2.BlobFinalize(fd=self.fd, data=data))
         self.syscall._send(req)
         response = self.syscall._recv(syscalls_pb2.BlobResponse())
         return response.data.decode("utf-8")

--- a/rootfs/runtimes/python3/syscalls.py
+++ b/rootfs/runtimes/python3/syscalls.py
@@ -693,13 +693,13 @@ class Syscall():
         """
         req = syscalls_pb2.Syscall(blobCreate=syscalls_pb2.BlobCreate(size=size))
         self._send(req)
-        response = self._recv(syscalls_pb2.BlobResponse())
+        response = self._recv(syscalls_pb2.BlobResult())
         if response.success:
             fd = response.fd
             yield NewBlob(fd, self)
             syscalls_pb2.Syscall(blobClose=syscalls_pb2.BlobClose(fd=fd))
             self._send(req)
-            response = self._recv(syscalls_pb2.BlobResponse())
+            response = self._recv(syscalls_pb2.BlobResult())
         else:
             raise CreateBlobError
 
@@ -712,12 +712,12 @@ class Syscall():
         """
         req = syscalls_pb2.Syscall(openBlob=syscalls_pb2.BlobOpen(name=name))
         self._send(req)
-        response = self._recv(syscalls_pb2.BlobResponse())
+        response = self._recv(syscalls_pb2.BlobResult())
         fd = response.fd
         yield Blob(fd, self)
         req = syscalls_pb2.Syscall(closeBlob=syscalls_pb2.BlobClose(fd=fd))
         self._send(req)
-        response = self._recv(syscalls_pb2.BlobResponse())
+        response = self._recv(syscalls_pb2.BlobResult())
     ### end of unnamed object syscalls ###
 
     ### return direntry handle ###
@@ -741,13 +741,13 @@ class NewBlob():
     def write(self, data):
         req = syscalls_pb2.Syscall(blobWrite=syscalls_pb2.BlobWrite(fd=self.fd, data=data))
         self.syscall._send(req)
-        response = self.syscall._recv(syscalls_pb2.BlobResponse())
+        response = self.syscall._recv(syscalls_pb2.BlobResult())
         return response.success
 
     def finalize(self, data):
         req = syscalls_pb2.Syscall(blobFinalize=syscalls_pb2.BlobFinalize(fd=self.fd, data=data))
         self.syscall._send(req)
-        response = self.syscall._recv(syscalls_pb2.BlobResponse())
+        response = self.syscall._recv(syscalls_pb2.BlobResult())
         return response.data.decode("utf-8")
 
 class CreateBlobError(Exception):

--- a/rootfs/runtimes/python3/syscalls.py
+++ b/rootfs/runtimes/python3/syscalls.py
@@ -745,7 +745,7 @@ class NewBlob():
         return response.success
 
     def finalize(self, data):
-        req = syscalls_pb2.Syscall(blobFinalize=syscalls_pb2.BlobFinalize(fd=self.fd, data=data))
+        req = syscalls_pb2.Syscall(blobFinalize=syscalls_pb2.BlobFinalize(fd=self.fd))
         self.syscall._send(req)
         response = self.syscall._recv(syscalls_pb2.BlobResult())
         return response.data.decode("utf-8")

--- a/snapfaas/src/vm.rs
+++ b/snapfaas/src/vm.rs
@@ -114,7 +114,7 @@ impl Vm {
             args.extend_from_slice(&["--appfs", f]);
         }
         if let Some(load_dir) = function_config.load_dir.as_ref() {
-            args.extend_from_slice(&["--load-from", load_dir]);
+            args.extend_from_slice(&["--load-dir", load_dir]);
             if function_config.copy_base {
                 args.push("--copy-base");
             }


### PR DESCRIPTION
This PR contains 3 things
1. Update Python library calls to match the current syscall interface.
2. Fix a typo in `vm.rs`
3. Bump the default bootstrap-config to use a newer Linux kernel image (5.10.210)

The image is built through this [script](https://github.com/firecracker-microvm/firecracker/blob/main/resources/rebuild.sh) provided by the firecracker repository. This image has been tested and confirmed working using Faasten's [faas-workbench](https://github.com/faasten/serverless-faas-workbench).